### PR TITLE
Set-up Matomo analytics

### DIFF
--- a/src/components/LegalTerms/index.tsx
+++ b/src/components/LegalTerms/index.tsx
@@ -5,7 +5,7 @@ import { CommonProps } from "@/types";
 export const SubTitle: React.FC<CommonProps> = ({ children, className }) => (
   <h2
     className={twMerge(
-      "text-[2rem] leading-9 font-bold mb-4 text-pretty",
+      "text-[1.5rem] md:text-[1.75rem] leading-9 font-bold mb-4 text-pretty",
       className,
     )}
   >

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -3,6 +3,7 @@ export const ADDRESS_DINUM = "DINUM, 20 avenue de Ségur 75007 Paris";
 
 export const URL_SITE = "lasuite.numerique.gouv.fr";
 export const TITLE_SITE = "La Suite numérique";
+export const MATOMO_ID = "https://stats.data.gouv.fr/js/container_h2RIEY3C.js";
 
 export const NEWSLETTER_FORM =
   "https://4f0df3d6.sibforms.com/serve/MUIFAKrbltNDRgRE9y7Ijv8nF1SN65VwHtbGH33ZGje0x0-VS9Rr8bbD3LefzRQE0Eu3KtRtSBbaDueFVEARVVYp2Bb3JLj9LBk9SNK1XX2rSgs9adgkR67Xhi1RUqGU7wcVv2U42hHq7IIyH3N3Eu82Ci39-aYzr2HUoNERYKoTbYfeINulmU8Y-BX6jaK5QNlZg6wyBhMl52sq";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,8 +2,44 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 
 import { MetaHeader as Head } from "@/components/Layout";
+import { MATOMO_ID } from "@/constant";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    _mtm?: any[];
+  }
+}
+
+/**
+ * Initializes Matomo tracking as per the Matomo integration guide.
+ *
+ * This function includes the necessary code snippets for setting up Matomo tracking
+ * on a web page. It initializes the Matomo tracking script and pushes the start event
+ * to the Matomo data layer.
+ *
+ * Note: This code is directly copied and pasted from the Matomo integration guide.
+ * Ensure that MATOMO_ID is correctly defined before using this function.
+ */
+function setUpMatomoAnalytics() {
+  // Push start event to the data layer
+  const _mtm = (window._mtm = window._mtm || []);
+  _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
+
+  // Add tracking script
+  const d = document;
+  const g = d.createElement("script");
+  const s = d.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = MATOMO_ID;
+  s?.parentNode?.insertBefore(g, s);
+}
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    setUpMatomoAnalytics();
+  }, []);
+
   return (
     <>
       <Head />

--- a/src/pages/accessibilite/index.tsx
+++ b/src/pages/accessibilite/index.tsx
@@ -70,7 +70,7 @@ export default function Accessibilite() {
               Écrire un message au{" "}
               <ExternalLink
                 href="https://formulaire.defenseurdesdroits.fr/formulaire_saisine/"
-                className="underline underline-offset-4"
+                className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
               >
                 Défenseur des droits
               </ExternalLink>
@@ -79,7 +79,7 @@ export default function Accessibilite() {
               Contacter le délégué du{" "}
               <ExternalLink
                 href="https://www.defenseurdesdroits.fr/carte-des-delegues"
-                className="underline underline-offset-4"
+                className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
               >
                 Défenseur des droits dans votre région
               </ExternalLink>

--- a/src/pages/apropos/index.tsx
+++ b/src/pages/apropos/index.tsx
@@ -34,7 +34,7 @@ export default function Apropos() {
             à{" "}
             <a
               href={`mailto:${CONTACT_EMAIL}`}
-              className="underline decoration-2 underline-offset-4 transition ease-in-out delay-50 duration-300 hover:cursor-pointer"
+              className="underline decoration-1 hover:decoration-2 underline-offset-4 transition ease-in-out delay-50 duration-300 hover:cursor-pointer"
               aria-label={`écrire à ${CONTACT_EMAIL}`}
             >
               {CONTACT_EMAIL}

--- a/src/pages/suivi/index.tsx
+++ b/src/pages/suivi/index.tsx
@@ -1,5 +1,8 @@
 import { Layout, ContentSection } from "@/components/Layout";
 import { SubTitle, Header, Text } from "@/components/LegalTerms";
+import { ExternalLink } from "@/components/Core";
+import React from "react";
+import { URL_SITE } from "@/constant";
 
 export default function Suivi() {
   return (
@@ -8,7 +11,22 @@ export default function Suivi() {
       <ContentSection classNameChildren="items-start max-w-[54rem]">
         <div>
           <SubTitle>Cookies déposés</SubTitle>
-          <p className="mb-3">Nous ne déposons aucun cookie.</p>
+          <Text>
+            Ce site dépose un petit fichier texte (un « cookie ») sur votre
+            ordinateur lorsque vous le consultez. Cela nous permet de mesurer le
+            nombre de visites et de comprendre quelles sont les pages les plus
+            consultées.
+          </Text>
+          <Text className="font-serif">
+            Vous pouvez vous opposer au suivi de votre navigation sur ce site
+            web. Cela protégera votre vie privée, mais empêchera également le
+            propriétaire d&apos;apprendre de vos actions et de créer une
+            meilleure expérience pour vous et les autres utilisateurs.
+          </Text>
+          <iframe
+            className="w-full"
+            src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=fr"
+          ></iframe>
         </div>
         <div>
           <SubTitle>
@@ -27,7 +45,31 @@ export default function Suivi() {
             sont exemptés d’autorisation préalable.
           </Text>
           <p className="mb-3">
-            Nous n’utilisons aucun outil pour surveiller les usages du site.
+            Nous utilisons pour cela{" "}
+            <ExternalLink
+              href="https://matomo.org/"
+              className="underline underline-offset-4"
+            >
+              Matomo
+            </ExternalLink>
+            , un outil{" "}
+            <ExternalLink
+              href="https://matomo.org/free-software/"
+              className="underline underline-offset-4"
+            >
+              libre
+            </ExternalLink>
+            , paramétré pour être en conformité avec la{" "}
+            <ExternalLink
+              href="https://www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies-solutions-pour-les-outils-de-mesure-daudience"
+              className="underline underline-offset-4"
+            >
+              recommandation « Cookies »
+            </ExternalLink>{" "}
+            de la <span className="decoration-dotted underline">CNIL</span>.
+            Cela signifie que votre adresse IP, par exemple, est anonymisée
+            avant d’être enregistrée. Il est donc impossible d’associer vos
+            visites sur ce site à votre personne.
           </p>
         </div>
         <div>
@@ -35,8 +77,15 @@ export default function Suivi() {
             Je contribue à enrichir vos données, puis-je y accéder ?
           </SubTitle>
           <Text>
-            Les statistisques d&apos;usage de nos produits ne sont pas encore en
-            accès libre.
+            Bien sûr ! Les statistiques d’usage de la majorité de nos produits,
+            dont {URL_SITE}, sont disponibles en accès libre sur{" "}
+            <ExternalLink
+              href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=21&period=range&date=previous30#?period=range&date=previous30&module=VisitsSummary&action=index&idSite=21&category=Dashboard_Dashboard&subcategory=1"
+              className="underline underline-offset-4"
+            >
+              stats.data.gouv.fr
+            </ExternalLink>{" "}
+            .
           </Text>
         </div>
       </ContentSection>

--- a/src/pages/suivi/index.tsx
+++ b/src/pages/suivi/index.tsx
@@ -48,21 +48,21 @@ export default function Suivi() {
             Nous utilisons pour cela{" "}
             <ExternalLink
               href="https://matomo.org/"
-              className="underline underline-offset-4"
+              className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
             >
               Matomo
             </ExternalLink>
             , un outil{" "}
             <ExternalLink
               href="https://matomo.org/free-software/"
-              className="underline underline-offset-4"
+              className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
             >
               libre
             </ExternalLink>
             , paramétré pour être en conformité avec la{" "}
             <ExternalLink
               href="https://www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies-solutions-pour-les-outils-de-mesure-daudience"
-              className="underline underline-offset-4"
+              className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
             >
               recommandation « Cookies »
             </ExternalLink>{" "}
@@ -81,7 +81,7 @@ export default function Suivi() {
             dont {URL_SITE}, sont disponibles en accès libre sur{" "}
             <ExternalLink
               href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=21&period=range&date=previous30#?period=range&date=previous30&module=VisitsSummary&action=index&idSite=21&category=Dashboard_Dashboard&subcategory=1"
-              className="underline underline-offset-4"
+              className="underline decoration-1 hover:decoration-2 transition ease-in-out delay-50 duration-300 underline-offset-4"
             >
               stats.data.gouv.fr
             </ExternalLink>{" "}


### PR DESCRIPTION
## Purpose

Offer analytics on page's visits to the communication/marketing team.

## Proposal

- [X] Setup Matomo per the React integration guide.
- [X] Add the official Iframe to allow user Opt Out tracking analytics.
- [X] Update Data and cookies page's content.
- [X] Minor changes in Legal pages UI.