### PR TITLE
💄(keyboard) make focusable cards style change only with keyboard

### DIFF
--- a/src/components/sections/CallForProjects/Card.tsx
+++ b/src/components/sections/CallForProjects/Card.tsx
@@ -10,7 +10,7 @@ export interface CardProps {
 export const Card = ({ title, body, index }: CardProps) => (
   <div
     tabIndex={0}
-    className="bg-dinum-blue-1 text-dinum-white-0 text-left px-6 py-14 sm:p-14 relative focus:m-2"
+    className="bg-dinum-blue-1 text-dinum-white-0 text-left px-6 py-14 sm:p-14 relative focus-visible:m-2"
   >
     <h3 className="text-3xl font-extrabold mb-7">
       Qu’est ce qu’un <Br /> {title}&nbsp;?


### PR DESCRIPTION
for accessibility, we made CallForProjects cards focusable with tab and changed a bit the layout to mark the focus. But clicking them also made them change the layout, we didn't want that. Now the card only changes visually when actually using the keyboard.