### PR TITLE
Take newsletter out of layout

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,13 +1,6 @@
-import Image from "next/image";
 import Link from "next/link";
 import { twMerge } from "tailwind-merge";
-import { NEWSLETTER_FORM } from "@/constant";
-import {
-  ExternalLink,
-  ButtonExternalLink,
-  LinkProps,
-  Br,
-} from "@/components/Core";
+import { ExternalLink, LinkProps, Br } from "@/components/Core";
 
 const hover =
   "hover:underline hover:decoration-2 hover:underline-offset-4 transition ease-in-out delay-50 duration-300 hover:cursor-pointer";
@@ -26,101 +19,75 @@ const pages: LinkProps[] = [
 ];
 
 export const Footer = () => (
-  <>
-    <div className="bg-dsfr-blue-1">
-      <div className="max-w-[78rem] px-[24px] mx-auto py-8">
-        <div className="flex flex-col items-start justify-between">
-          <h2 className="text-[1.375rem] leading-7 font-bold mb-3">
-            Recevoir la newsletter de La Suite
-          </h2>
-          <p className="text-[.875rem] leading-6 mb-6">
-            Restez informés des prochaines avancées de La Suite en recevant la
-            newsletter !
+  <footer className="pt-8 border-t-2 border-dinum-blue-1 pb-40">
+    <div className="fr-container">
+      <div className="flex flex-wrap justify-between mb-6">
+        <Link
+          className="w-fit md:flex items-center gap-10 hover:bg-dinum-white-1 p-4 pl-0 transition ease-in-out delay-50 duration-300 min-w-[114px] ml-[-0.5rem] "
+          href="/"
+          aria-label="Retour à l'accueil"
+        >
+          <p className="logo text-[0.7875rem] font-bold leading-[1.0317460317em] tracking-[-.01em] pl-2 uppercase align-middle inline-block">
+            république
+            <Br className="inline" />
+            française
           </p>
-          <p>
-            <ButtonExternalLink
-              href={NEWSLETTER_FORM}
-              aria-label="S'inscrire à la newsletter"
+        </Link>
+        <div className="basis-full md:basis-2/3 max-w-2xl">
+          <p className="text-sm leading-6 text-dinum-grey-5">
+            Ce site est géré par La Suite Numérique à la Direction
+            Interministérielle du Numérique (DINUM).
+          </p>
+          <ul className="flex flex-wrap align-middle mt-2">
+            {externalLinks.map((link) => (
+              <li
+                key={link.href}
+                className={twMerge("mr-6 my-2 decoration-dinum-grey-5", hover)}
+              >
+                <ExternalLink
+                  className="font-bold text-sm text-dinum-grey-5 external-link-grey"
+                  {...link}
+                >
+                  {link.children}
+                </ExternalLink>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="mt-4 border-t border-dinum-grey-0 flex flex-row flex-wrap">
+        <div className="mt-2 mb-4 sm:mb-0 w-[75%] m-w-[75%]">
+          <ul className="block justify-start flex-wrap">
+            {pages.map((link) => (
+              <li
+                key={link.href}
+                className="inline internal-link-footer text-xs text-dinum-grey-3"
+              >
+                <Link
+                  {...link}
+                  className={twMerge("border-dinum-grey-1", hover)}
+                >
+                  {link.children}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="mt-2">
+          <p className="inline text-xs text-dinum-grey-3 leading-5">
+            Sauf mention contraire, tous les contenus de ce site sont sous{" "}
+            <ExternalLink
+              href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+              className={twMerge(
+                "relative underline underline-offset-4 external-link-grey",
+                hover
+              )}
             >
-              S&apos;inscrire
-            </ButtonExternalLink>
+              licence etalab-2.0
+            </ExternalLink>
           </p>
         </div>
       </div>
     </div>
-    <footer className="pt-8 border-t-2 border-dinum-blue-1 pb-40">
-      <div className="fr-container">
-        <div className="flex flex-wrap justify-between mb-6">
-          <Link
-            className="w-fit md:flex items-center gap-10 hover:bg-dinum-white-1 p-4 pl-0 transition ease-in-out delay-50 duration-300 min-w-[114px] ml-[-0.5rem] "
-            href="/"
-            aria-label="Retour à l'accueil"
-          >
-            <p className="logo text-[0.7875rem] font-bold leading-[1.0317460317em] tracking-[-.01em] pl-2 uppercase align-middle inline-block">
-              république
-              <Br className="inline" />
-              française
-            </p>
-          </Link>
-          <div className="basis-full md:basis-2/3 max-w-2xl">
-            <p className="text-sm leading-6 text-dinum-grey-5">
-              Ce site est géré par La Suite Numérique à la Direction
-              Interministérielle du Numérique (DINUM).
-            </p>
-            <ul className="flex flex-wrap align-middle mt-2">
-              {externalLinks.map((link) => (
-                <li
-                  key={link.href}
-                  className={twMerge(
-                    "mr-6 my-2 decoration-dinum-grey-5",
-                    hover,
-                  )}
-                >
-                  <ExternalLink
-                    className="font-bold text-sm text-dinum-grey-5 external-link-grey"
-                    {...link}
-                  >
-                    {link.children}
-                  </ExternalLink>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-        <div className="mt-4 border-t border-dinum-grey-0 flex flex-row flex-wrap">
-          <div className="mt-2 mb-4 sm:mb-0 w-[75%] m-w-[75%]">
-            <ul className="block justify-start flex-wrap">
-              {pages.map((link) => (
-                <li
-                  key={link.href}
-                  className="inline internal-link-footer text-xs text-dinum-grey-3"
-                >
-                  <Link
-                    {...link}
-                    className={twMerge("border-dinum-grey-1", hover)}
-                  >
-                    {link.children}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="mt-2">
-            <p className="inline text-xs text-dinum-grey-3 leading-5">
-              Sauf mention contraire, tous les contenus de ce site sont sous{" "}
-              <ExternalLink
-                href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
-                className={twMerge(
-                  "relative underline underline-offset-4 external-link-grey",
-                  hover,
-                )}
-              >
-                licence etalab-2.0
-              </ExternalLink>
-            </p>
-          </div>
-        </div>
-      </div>
-    </footer>
-  </>
+  </footer>
 );

--- a/src/components/sections/Newsletter/index.tsx
+++ b/src/components/sections/Newsletter/index.tsx
@@ -1,0 +1,26 @@
+import { ButtonExternalLink } from "@/components/Core";
+import { NEWSLETTER_FORM } from "@/constant";
+
+export const Section = () => (
+  <div className="bg-dsfr-blue-1 py-8 text-left">
+    <div className="max-w-[78rem] px-[24px] mx-auto py-8">
+      <div className="flex flex-col items-start justify-between">
+        <h2 className="text-[1.375rem] leading-7 font-bold mb-3">
+          Recevoir la newsletter de La Suite
+        </h2>
+        <p className="text-[.875rem] leading-6 mb-6">
+          Restez informés des prochaines avancées de La Suite en recevant la
+          newsletter !
+        </p>
+        <p>
+          <ButtonExternalLink
+            href={NEWSLETTER_FORM}
+            aria-label="S'inscrire à la newsletter"
+          >
+            S&apos;inscrire
+          </ButtonExternalLink>
+        </p>
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/sections/Newsletter/index.tsx
+++ b/src/components/sections/Newsletter/index.tsx
@@ -3,7 +3,7 @@ import { NEWSLETTER_FORM } from "@/constant";
 
 export const Section = () => (
   <div className="bg-dsfr-blue-1 py-8 text-left">
-    <div className="max-w-[78rem] px-[24px] mx-auto py-8">
+    <div className="fr-container">
       <div className="flex flex-col items-start justify-between">
         <h2 className="text-[1.375rem] leading-7 font-bold mb-3">
           Recevoir la newsletter de La Suite

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { Section as ANCT } from "@/components/sections/ANCT";
 import { Section as Testimony } from "@/components/sections/Testimony";
 import { Section as CallForProjects } from "@/components/sections/CallForProjects";
 import { Section as ProConnect } from "@/components/sections/ProConnect";
+import { Section as Newsletter } from "@/components/sections/Newsletter";
 import { TITLE_SITE } from "@/constant";
 
 export default function Landing() {
@@ -16,6 +17,7 @@ export default function Landing() {
       <CallForProjects />
       <Testimony />
       <ANCT />
+      <Newsletter />
     </Layout>
   );
 }


### PR DESCRIPTION
After https://github.com/numerique-gouv/lasuite-landingpage/pull/7 changes, I noticed the newsletter was different from Figma:

- now it's the correct width (match the landing page width. to match even better to figma design we could also resize the text of the ANCT `<p>` but I figured we could do that later if the content changes)
- now it's only rendered in the landing page and not part of the main footer as it seems to be the idea from figma