### PR TITLE
🐛(typography)  fix Marianne font not displaying if not installed locally

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,3 +1,5 @@
+@import "./Marianne-font.css";
+
 #root,
 #__next {
   isolation: isolate;


### PR DESCRIPTION
The Marianne font was not rendering for clients who didn't have the font installed locally, as the font stylesheet was not properly imported. This led to a situation where no font static files were loaded, causing a display issue.

Special thanks to @manuhabitela for catching and highlighting this issue.