### PR TITLE
Visual changes for better accessibility (including a small tailwind refactor)

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,7 +8,7 @@ interface ButtonProps extends CommonProps {
 }
 
 export const ButtonStyle =
-  'flex justify-center align-middle items-center min-h-10 text-base font-medium text-dinum-white-0 px-6 sm:w-auto bg-dinum-blue-1 hover:bg-dsfr-blue-2 transition ease-in-out delay-50 duration-300 text-center'
+  'flex justify-center align-middle items-center min-h-10 text-base font-medium text-white-0 px-6 sm:w-auto bg-blue-1 hover:bg-dsfr-blue-2 transition ease-in-out delay-50 duration-300 text-center'
 
 export const Button: React.FC<ButtonProps> = ({
   children,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,7 +8,7 @@ interface ButtonProps extends CommonProps {
 }
 
 export const ButtonStyle =
-  'flex justify-center align-middle items-center min-h-10 text-base font-medium text-white-0 px-6 sm:w-auto bg-blue-1 hover:bg-dsfr-blue-2 transition ease-in-out delay-50 duration-300 text-center'
+  'flex justify-center align-middle items-center min-h-10 text-base font-medium text-white px-6 sm:w-auto bg-blue-1 hover:bg-dsfr-blue-2 transition ease-in-out delay-50 duration-300 text-center'
 
 export const Button: React.FC<ButtonProps> = ({
   children,

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -16,9 +16,7 @@ export const Callout = ({ children }: CalloutProps) => (
       alt=""
     />
     <div className="w-full flex justify-center text-left sm:text-center">
-      <p className="text-xl sm:text-2xl text-dinum-blue-1 font-bold">
-        {children}
-      </p>
+      <p className="text-xl sm:text-2xl text-blue-1 font-bold">{children}</p>
     </div>
     <Image
       className="rotate-180 flex absolute bottom-[-1.3rem] right-[-1.3rem] h-[1.3rem] w-[1.3rem]"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,7 +20,7 @@ const pages: LinkProps[] = [
 ]
 
 export const Footer = () => (
-  <footer className="pt-8 border-t-2 border-blue-1 pb-40">
+  <footer className="pt-8 border-t-2 bg-white border-blue-1 pb-40">
     <div className="fr-container">
       <div className="flex flex-wrap justify-between mb-6">
         <Link

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,11 +20,11 @@ const pages: LinkProps[] = [
 ]
 
 export const Footer = () => (
-  <footer className="pt-8 border-t-2 border-dinum-blue-1 pb-40">
+  <footer className="pt-8 border-t-2 border-blue-1 pb-40">
     <div className="fr-container">
       <div className="flex flex-wrap justify-between mb-6">
         <Link
-          className="w-fit md:flex items-center gap-10 hover:bg-dinum-white-1 p-4 pl-0 transition ease-in-out delay-50 duration-300 min-w-[114px] ml-[-0.5rem] "
+          className="w-fit md:flex items-center gap-10 hover:bg-white-1 p-4 pl-0 transition ease-in-out delay-50 duration-300 min-w-[114px] ml-[-0.5rem] "
           href="/"
           aria-label="Retour à l'accueil"
         >
@@ -35,7 +35,7 @@ export const Footer = () => (
           </p>
         </Link>
         <div className="basis-full md:basis-2/3 max-w-2xl">
-          <p className="text-sm leading-6 text-dinum-grey-5">
+          <p className="text-sm leading-6 text-grey-5">
             Ce site est géré par La Suite Numérique de la direction
             interministérielle du numérique (DINUM) en charge de la
             transformation numérique de l’État.
@@ -44,10 +44,10 @@ export const Footer = () => (
             {externalLinks.map((link) => (
               <li
                 key={link.href}
-                className={twMerge('mr-6 my-2 decoration-dinum-grey-5', hover)}
+                className={twMerge('mr-6 my-2 decoration-grey-5', hover)}
               >
                 <ExternalLink
-                  className="font-bold text-sm text-dinum-grey-5 external-link-grey"
+                  className="font-bold text-sm text-grey-5 external-link-grey"
                   {...link}
                 >
                   {link.children}
@@ -57,18 +57,15 @@ export const Footer = () => (
           </ul>
         </div>
       </div>
-      <div className="mt-4 border-t border-dinum-grey-0 flex flex-row flex-wrap">
+      <div className="mt-4 border-t border-grey-0 flex flex-row flex-wrap">
         <div className="mt-2 mb-4 sm:mb-0 w-[75%] m-w-[75%]">
           <ul className="block justify-start flex-wrap">
             {pages.map((link) => (
               <li
                 key={link.href}
-                className="inline internal-link-footer text-xs text-dinum-grey-3"
+                className="inline internal-link-footer text-xs text-grey-3"
               >
-                <Link
-                  {...link}
-                  className={twMerge('border-dinum-grey-1', hover)}
-                >
+                <Link {...link} className={twMerge('border-grey-1', hover)}>
                   {link.children}
                 </Link>
               </li>
@@ -76,7 +73,7 @@ export const Footer = () => (
           </ul>
         </div>
         <div className="mt-2">
-          <p className="inline text-xs text-dinum-grey-3 leading-5">
+          <p className="inline text-xs text-grey-3 leading-5">
             Sauf mention contraire, tous les contenus de ce site sont sous{' '}
             <ExternalLink
               href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -8,7 +8,7 @@ import { Br } from '@/components/Br'
  * We kinda match DSFR styling here but with custom dom/classes for our specific use case.
  */
 export const NavBar = () => (
-  <header className="bg-white-0 navbar-shadow">
+  <header className="bg-white navbar-shadow">
     <div className="fr-container">
       <div className="-mx-4 lg:w-fit lg:py-2">
         <div className="sm:flex items-center fr-enlarge-link hover:bg-white-1 rounded transition ease-in-out delay-50 duration-300">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -8,16 +8,16 @@ import { Br } from '@/components/Br'
  * We kinda match DSFR styling here but with custom dom/classes for our specific use case.
  */
 export const NavBar = () => (
-  <header className="bg-dinum-white-0 navbar-shadow">
+  <header className="bg-white-0 navbar-shadow">
     <div className="fr-container">
       <div className="-mx-4 lg:w-fit lg:py-2">
-        <div className="sm:flex items-center fr-enlarge-link hover:bg-dinum-white-1 rounded transition ease-in-out delay-50 duration-300">
+        <div className="sm:flex items-center fr-enlarge-link hover:bg-white-1 rounded transition ease-in-out delay-50 duration-300">
           <p className="p-4 logo text-[0.7875rem] font-bold leading-[1.0317460317em] tracking-[-.01em] uppercase align-middle inline-block">
             république
             <Br className="inline" />
             française
           </p>
-          <p className="p-4 border-t border-dinum-grey-4 sm:border-0">
+          <p className="p-4 border-t border-grey-4 sm:border-0">
             <Link
               className="block text-xl"
               href="/"
@@ -26,7 +26,7 @@ export const NavBar = () => (
               <strong>lasuite.numerique.gouv.</strong>
               <i>fr</i>
             </Link>
-            <span className="block text-xs sm:text-sm text-dinum-black-1">
+            <span className="block text-xs sm:text-sm text-black-1">
               Un État efficace, simple, souverain grâce au numérique
             </span>
           </p>

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -14,7 +14,7 @@ export const PageLayout: React.FC<{
           {title}
         </h1>
       </div>
-      <div className="fr-container page-content py-12">
+      <div className="fr-container page-content py-12 bg-white text-body">
         <div className="max-w-[50rem]">{children}</div>
       </div>
     </Layout>

--- a/src/pages/communs.tsx
+++ b/src/pages/communs.tsx
@@ -9,8 +9,8 @@ import InitiativesFinance from '@/assets/initiatives-finance.svg'
 
 export default function Communs() {
   return (
-    <Layout title="Le Fonds Communs Numériques">
-      <div className="hero relative overflow-hidden bg-white ">
+    <Layout title="Le Fonds Communs Numériques" className="bg-white text-body">
+      <div className="hero relative overflow-hidden">
         <div className="flex flex-col justify-between items-center gap-11 py-10 md:py-20 max-w-[40em] mx-auto">
           <Image
             src={LogoSvg}
@@ -26,12 +26,12 @@ export default function Communs() {
             <h2 className="text-xl font-bold mb-[1.75rem]">
               Qu&apos;est-ce que le Fonds&nbsp;?
             </h2>
-            <p className="text-lg text-grey-1 mb-[1.75rem]">
+            <p className="text-lg mb-[1.75rem]">
               Avec <strong>La Suite numérique</strong>, notre défi est
               d’apporter aux agents publics de nouveaux outils de travail
               ouverts et propices aux usages collaboratifs.
             </p>
-            <p className="text-lg text-grey-1 mb-[3rem]">
+            <p className="text-lg mb-[3rem]">
               La DINUM ne développe pas directement les produits de La Suite
               numérique, mais s’emploie à constituer un système inter-opérable
               et simple d’utilisation, composé d’outils développés par d’autres
@@ -54,7 +54,7 @@ export default function Communs() {
               {' '}
               De quoi bénéficient les projets sélectionnés&nbsp;?
             </h2>
-            <ul className="text-lg text-grey-1 list-disc pl-10">
+            <ul className="text-lg list-disc pl-10">
               <li>
                 Un ticket de financement allant jusqu&apos;à{' '}
                 <strong>40.000 euros renouvelable.</strong>
@@ -84,7 +84,7 @@ export default function Communs() {
         <Image src={InitiativesPlaning} width={800} height={640} alt="" />
       </div>
       <div className="flex flex-col">
-        <div className="text-left px-4 text-lg text-grey-1 max-w-[40em] mx-auto">
+        <div className="text-left px-4 text-lg max-w-[40em] mx-auto">
           <h3 className="mt-[1.75rem] text-xl text-black font-bold ">
             Mars 2024
           </h3>
@@ -100,7 +100,7 @@ export default function Communs() {
             apprentissages de la coopération.
           </p>
         </div>
-        <div className="text-left px-4 text-lg text-grey-1 max-w-[40em] mx-auto">
+        <div className="text-left px-4 text-lg max-w-[40em] mx-auto">
           <h3 className="text-xl text-black font-bold ">Septembre 2024</h3>
           <p className="mb-[1.75rem] mt-[0.875rem]">
             <strong>Objectif de ce deuxième temps :</strong> étendre la

--- a/src/pages/communs.tsx
+++ b/src/pages/communs.tsx
@@ -10,7 +10,7 @@ import InitiativesFinance from '@/assets/initiatives-finance.svg'
 export default function Communs() {
   return (
     <Layout title="Le Fonds Communs Numériques">
-      <div className="hero relative overflow-hidden bg-white-0 ">
+      <div className="hero relative overflow-hidden bg-white ">
         <div className="flex flex-col justify-between items-center gap-11 py-10 md:py-20 max-w-[40em] mx-auto">
           <Image
             src={LogoSvg}

--- a/src/pages/communs.tsx
+++ b/src/pages/communs.tsx
@@ -10,7 +10,7 @@ import InitiativesFinance from '@/assets/initiatives-finance.svg'
 export default function Communs() {
   return (
     <Layout title="Le Fonds Communs Numériques">
-      <div className="hero relative overflow-hidden bg-dinum-white-0 ">
+      <div className="hero relative overflow-hidden bg-white-0 ">
         <div className="flex flex-col justify-between items-center gap-11 py-10 md:py-20 max-w-[40em] mx-auto">
           <Image
             src={LogoSvg}
@@ -26,12 +26,12 @@ export default function Communs() {
             <h2 className="text-xl font-bold mb-[1.75rem]">
               Qu&apos;est-ce que le Fonds&nbsp;?
             </h2>
-            <p className="text-lg text-dinum-grey-1 mb-[1.75rem]">
+            <p className="text-lg text-grey-1 mb-[1.75rem]">
               Avec <strong>La Suite numérique</strong>, notre défi est
               d’apporter aux agents publics de nouveaux outils de travail
               ouverts et propices aux usages collaboratifs.
             </p>
-            <p className="text-lg text-dinum-grey-1 mb-[3rem]">
+            <p className="text-lg text-grey-1 mb-[3rem]">
               La DINUM ne développe pas directement les produits de La Suite
               numérique, mais s’emploie à constituer un système inter-opérable
               et simple d’utilisation, composé d’outils développés par d’autres
@@ -40,7 +40,7 @@ export default function Communs() {
               techniques que nous utilisons. Vous êtes une entité publique ou
               privée et vous portez une solution collaborative structurée sous
               forme de commun numérique&nbsp;? <Br className="inline" />{' '}
-              <b className="text-dinum-grey-2">
+              <b className="text-grey-2">
                 Obtenez un financement et un accompagnement pour travailler avec
                 nous, dans le cadre du Fonds Communs Numériques pour La Suite
                 numérique.
@@ -54,7 +54,7 @@ export default function Communs() {
               {' '}
               De quoi bénéficient les projets sélectionnés&nbsp;?
             </h2>
-            <ul className="text-lg text-dinum-grey-1 list-disc pl-10">
+            <ul className="text-lg text-grey-1 list-disc pl-10">
               <li>
                 Un ticket de financement allant jusqu&apos;à{' '}
                 <strong>40.000 euros renouvelable.</strong>
@@ -84,7 +84,7 @@ export default function Communs() {
         <Image src={InitiativesPlaning} width={800} height={640} alt="" />
       </div>
       <div className="flex flex-col">
-        <div className="text-left px-4 text-lg text-dinum-grey-1 max-w-[40em] mx-auto">
+        <div className="text-left px-4 text-lg text-grey-1 max-w-[40em] mx-auto">
           <h3 className="mt-[1.75rem] text-xl text-black font-bold ">
             Mars 2024
           </h3>
@@ -100,7 +100,7 @@ export default function Communs() {
             apprentissages de la coopération.
           </p>
         </div>
-        <div className="text-left px-4 text-lg text-dinum-grey-1 max-w-[40em] mx-auto">
+        <div className="text-left px-4 text-lg text-grey-1 max-w-[40em] mx-auto">
           <h3 className="text-xl text-black font-bold ">Septembre 2024</h3>
           <p className="mb-[1.75rem] mt-[0.875rem]">
             <strong>Objectif de ce deuxième temps :</strong> étendre la

--- a/src/sections/Anct.tsx
+++ b/src/sections/Anct.tsx
@@ -7,7 +7,7 @@ import AnssiSvg from '@/assets/logo/anssi.svg'
 import France20230Svg from '@/assets/logo/france-2030.svg'
 
 export const Anct = () => (
-  <ContentSection className="bg-white-0">
+  <ContentSection className="bg-white">
     <h2 className="text-3xl md:text-4xl font-bold flex flex-row items-center gap-6">
       <Image
         src={SuiteTerritoriale}

--- a/src/sections/Anct.tsx
+++ b/src/sections/Anct.tsx
@@ -7,7 +7,7 @@ import AnssiSvg from '@/assets/logo/anssi.svg'
 import France20230Svg from '@/assets/logo/france-2030.svg'
 
 export const Anct = () => (
-  <ContentSection className="bg-white">
+  <ContentSection className="bg-white text-body">
     <h2 className="text-3xl md:text-4xl font-bold flex flex-row items-center gap-6">
       <Image
         src={SuiteTerritoriale}
@@ -16,8 +16,8 @@ export const Anct = () => (
         alt="La Suite Territoriale"
       />
     </h2>
-    <div className="flex flex-col gap-4">
-      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
+    <div className="flex flex-col gap-4 text-lg max-w-[45em] text-left sm:text-center">
+      <p>
         Afin de{' '}
         <strong>
           renforcer la cybersécurité des collectivités territoriales,
@@ -25,14 +25,14 @@ export const Anct = () => (
         ANCT et ANSSI proposent de contribuer à l’ouverture de La Suite
         numérique aux élus locaux et agents publics territoriaux.
       </p>
-      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
+      <p>
         <strong>
           La Suite territoriale vise ainsi à mettre à disposition des
           collectivités un ensemble de services numériques sécurisés,
         </strong>{' '}
         notamment nom de domaine, serveur mail et espace de stockage minimal.
       </p>
-      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
+      <p>
         <strong>
           Ces services de base seront complétés par des services opérés au
           niveau national
@@ -41,7 +41,7 @@ export const Anct = () => (
         publics de services numériques) à travers La Suite numérique :
         visioconférence, transfert de fichiers lourds, tableur collaboratif…
       </p>
-      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
+      <p>
         <strong>
           L&apos;ANCT propose aux collectivités territoriales et partenaires
           locaux de participer aux développements de La Suite territoriale

--- a/src/sections/Anct.tsx
+++ b/src/sections/Anct.tsx
@@ -16,7 +16,7 @@ export const Anct = () => (
         alt="La Suite Territoriale"
       />
     </h2>
-    <div className="flex flex-col gap-4 text-lg max-w-[45em] text-left sm:text-center">
+    <div className="flex flex-col gap-4 text-lg max-w-[45em] text-left">
       <p>
         Afin de{' '}
         <strong>

--- a/src/sections/Anct.tsx
+++ b/src/sections/Anct.tsx
@@ -7,7 +7,7 @@ import AnssiSvg from '@/assets/logo/anssi.svg'
 import France20230Svg from '@/assets/logo/france-2030.svg'
 
 export const Anct = () => (
-  <ContentSection className="bg-dinum-white-0">
+  <ContentSection className="bg-white-0">
     <h2 className="text-3xl md:text-4xl font-bold flex flex-row items-center gap-6">
       <Image
         src={SuiteTerritoriale}
@@ -17,7 +17,7 @@ export const Anct = () => (
       />
     </h2>
     <div className="flex flex-col gap-4">
-      <p className="text-lg text-dinum-grey-1 max-w-[45em] text-left sm:text-center">
+      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
         Afin de{' '}
         <strong>
           renforcer la cybersécurité des collectivités territoriales,
@@ -25,14 +25,14 @@ export const Anct = () => (
         ANCT et ANSSI proposent de contribuer à l’ouverture de La Suite
         numérique aux élus locaux et agents publics territoriaux.
       </p>
-      <p className="text-lg text-dinum-grey-1 max-w-[45em] text-left sm:text-center">
+      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
         <strong>
           La Suite territoriale vise ainsi à mettre à disposition des
           collectivités un ensemble de services numériques sécurisés,
         </strong>{' '}
         notamment nom de domaine, serveur mail et espace de stockage minimal.
       </p>
-      <p className="text-lg text-dinum-grey-1 max-w-[45em] text-left sm:text-center">
+      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
         <strong>
           Ces services de base seront complétés par des services opérés au
           niveau national
@@ -41,7 +41,7 @@ export const Anct = () => (
         publics de services numériques) à travers La Suite numérique :
         visioconférence, transfert de fichiers lourds, tableur collaboratif…
       </p>
-      <p className="text-lg text-dinum-grey-1 max-w-[45em] text-left sm:text-center">
+      <p className="text-lg text-grey-1 max-w-[45em] text-left sm:text-center">
         <strong>
           L&apos;ANCT propose aux collectivités territoriales et partenaires
           locaux de participer aux développements de La Suite territoriale

--- a/src/sections/DigitalCommons.tsx
+++ b/src/sections/DigitalCommons.tsx
@@ -22,7 +22,7 @@ interface CardProps {
 const Card: React.FC<CardProps> = ({ img, title, href }) => (
   <div className="flex flex-col items-center">
     <Image src={img} height={92} width={92} alt="" />
-    <h3 className="text-lg text-grey-1 mt-6 mb-4">{title}</h3>
+    <h3 className="text-lg text-body mt-6 mb-4">{title}</h3>
     <div className="flex gap-1 justify-center items-center">
       <ExternalLink
         className="text-sm underline text-blue-1 external-link-blue"
@@ -75,7 +75,7 @@ const data: CardProps[] = [
 
 export const DigitalCommons = () => (
   <>
-    <ContentSection className="bg-white text">
+    <ContentSection className="bg-white text-body">
       <h2 className="text-3xl md:text-4xl max-w-[33rem] font-bold">
         <span aria-hidden={true}>
           Des applications à la carte et inter-connectées…
@@ -100,10 +100,10 @@ export const DigitalCommons = () => (
         className="mb-[-3rem] mt-[-1.5rem] sm:hidden"
       />
     </ContentSection>
-    <ContentSection className="bg-white pt-0 md:pt-0">
+    <ContentSection className="bg-white text-body pt-0 md:pt-0">
       <div
         aria-hidden={true}
-        className="text-3xl md:text-4xl max-w-[33rem] font-bold"
+        className="text-3xl text-title md:text-4xl max-w-[33rem] font-bold"
       >
         … basées sur des communs numériques libres
       </div>
@@ -124,7 +124,7 @@ export const DigitalCommons = () => (
       {/*<Callout>*/}
       {/*  La Suite est un ensemble de communs numériques libres reliés grâce au bouton Pro Connect*/}
       {/*</Callout>*/}
-      <p className="text-lg text-grey-1 max-w-[38em] text-left sm:text-center">
+      <p className="text-lg max-w-[38em] text-left sm:text-center">
         Les applications de La Suite numérique respectent un cahier des charges
         vertueux :{' '}
         <strong>

--- a/src/sections/DigitalCommons.tsx
+++ b/src/sections/DigitalCommons.tsx
@@ -75,7 +75,7 @@ const data: CardProps[] = [
 
 export const DigitalCommons = () => (
   <>
-    <ContentSection className="bg-white-0 text">
+    <ContentSection className="bg-white text">
       <h2 className="text-3xl md:text-4xl max-w-[33rem] font-bold">
         <span aria-hidden={true}>
           Des applications à la carte et inter-connectées…
@@ -100,7 +100,7 @@ export const DigitalCommons = () => (
         className="mb-[-3rem] mt-[-1.5rem] sm:hidden"
       />
     </ContentSection>
-    <ContentSection className="bg-white-0 pt-0 md:pt-0">
+    <ContentSection className="bg-white pt-0 md:pt-0">
       <div
         aria-hidden={true}
         className="text-3xl md:text-4xl max-w-[33rem] font-bold"

--- a/src/sections/DigitalCommons.tsx
+++ b/src/sections/DigitalCommons.tsx
@@ -22,10 +22,10 @@ interface CardProps {
 const Card: React.FC<CardProps> = ({ img, title, href }) => (
   <div className="flex flex-col items-center">
     <Image src={img} height={92} width={92} alt="" />
-    <h3 className="text-lg text-dinum-grey-1 mt-6 mb-4">{title}</h3>
+    <h3 className="text-lg text-grey-1 mt-6 mb-4">{title}</h3>
     <div className="flex gap-1 justify-center items-center">
       <ExternalLink
-        className="text-sm underline text-dinum-blue-1 external-link-blue"
+        className="text-sm underline text-blue-1 external-link-blue"
         href={href}
         aria-label={`${title} - En savoir plus`}
       >
@@ -75,7 +75,7 @@ const data: CardProps[] = [
 
 export const DigitalCommons = () => (
   <>
-    <ContentSection className="bg-dinum-white-0 text">
+    <ContentSection className="bg-white-0 text">
       <h2 className="text-3xl md:text-4xl max-w-[33rem] font-bold">
         <span aria-hidden={true}>
           Des applications à la carte et inter-connectées…
@@ -100,7 +100,7 @@ export const DigitalCommons = () => (
         className="mb-[-3rem] mt-[-1.5rem] sm:hidden"
       />
     </ContentSection>
-    <ContentSection className="bg-dinum-white-0 pt-0 md:pt-0">
+    <ContentSection className="bg-white-0 pt-0 md:pt-0">
       <div
         aria-hidden={true}
         className="text-3xl md:text-4xl max-w-[33rem] font-bold"
@@ -124,7 +124,7 @@ export const DigitalCommons = () => (
       {/*<Callout>*/}
       {/*  La Suite est un ensemble de communs numériques libres reliés grâce au bouton Pro Connect*/}
       {/*</Callout>*/}
-      <p className="text-lg text-dinum-grey-1 max-w-[38em] text-left sm:text-center">
+      <p className="text-lg text-grey-1 max-w-[38em] text-left sm:text-center">
         Les applications de La Suite numérique respectent un cahier des charges
         vertueux :{' '}
         <strong>

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -20,7 +20,7 @@ export const Hero = () => (
           priority
         />
       </h1>
-      <p className="text-lg text-grey-1 max-w-[44rem] text-left sm:text-center pb-8 md:pb-0">
+      <p className="text-lg text-body max-w-[44rem] text-left sm:text-center pb-8 md:pb-0">
         <strong>
           La Suite numérique vise à fédèrer tous les agents et professionnels de
           la sphère publique{' '}

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -8,7 +8,7 @@ import heroImageMobile from '@/assets/hero-mobile.webp'
 import LogoSvg from '@/assets/logo/suite-numerique.svg'
 
 export const Hero = () => (
-  <div className="hero relative overflow-hidden bg-white-0 ">
+  <div className="hero relative overflow-hidden bg-white ">
     <div className="flex flex-col justify-between items-start sm:items-center px-8 py-10 sm:py-20 md:bg-[url(/assets/bg-nid-abeille.webp)] md:bg-no-repeat md:bg-center">
       <h1 className="w-full flex justify-center pb-11">
         <Image

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -8,7 +8,7 @@ import heroImageMobile from '@/assets/hero-mobile.webp'
 import LogoSvg from '@/assets/logo/suite-numerique.svg'
 
 export const Hero = () => (
-  <div className="hero relative overflow-hidden bg-dinum-white-0 ">
+  <div className="hero relative overflow-hidden bg-white-0 ">
     <div className="flex flex-col justify-between items-start sm:items-center px-8 py-10 sm:py-20 md:bg-[url(/assets/bg-nid-abeille.webp)] md:bg-no-repeat md:bg-center">
       <h1 className="w-full flex justify-center pb-11">
         <Image
@@ -20,7 +20,7 @@ export const Hero = () => (
           priority
         />
       </h1>
-      <p className="text-lg text-dinum-grey-1 max-w-[44rem] text-left sm:text-center pb-8 md:pb-0">
+      <p className="text-lg text-grey-1 max-w-[44rem] text-left sm:text-center pb-8 md:pb-0">
         <strong>
           La Suite numérique vise à fédèrer tous les agents et professionnels de
           la sphère publique{' '}

--- a/src/sections/Initiatives.tsx
+++ b/src/sections/Initiatives.tsx
@@ -59,7 +59,7 @@ const Card = ({ title, body, index }: CardProps) => (
     tabIndex={0}
     className="bg-blue-1 text-white text-left px-6 py-14 sm:p-14 relative focus-visible:m-2 md:basis-1/2"
   >
-    <h3 className="text-3xl font-extrabold mb-7">
+    <h3 className="text-3xl text-white font-extrabold mb-7">
       Qu’est ce qu’un <Br /> {title}&nbsp;?
     </h3>
     <p className="text-lg" dangerouslySetInnerHTML={{ __html: body }} />
@@ -80,7 +80,7 @@ const data: Omit<CardProps, 'index'>[] = [
 
 export const Initiatives = () => (
   <>
-    <ContentSection className="bg-white-1 text-left sm:text-center">
+    <ContentSection className="bg-white-1 text-body text-left sm:text-center">
       <h2 className="text-3xl md:text-4xl font-bold max-w-[34rem] text-center">
         Contribuer à La&nbsp;Suite numérique, c’est possible&nbsp;!
       </h2>
@@ -91,7 +91,7 @@ export const Initiatives = () => (
         alt=""
         placeholder="blur"
       />
-      <p className="text-lg text-grey-1 max-w-[38rem] text-pretty">
+      <p className="text-lg max-w-[38rem] text-pretty">
         Vous êtes une entité publique ou privée et vous portez une solution
         collaborative structurée sous forme de commun numérique ou de logiciel
         libre ? Vous pouvez intégrer La Suite numérique{' '}
@@ -99,7 +99,7 @@ export const Initiatives = () => (
           pour être utile à des milliers d&apos;agents publics en France&nbsp;!
         </strong>
       </p>
-      <p className="text-lg text-grey-1 max-w-[38rem] text-pretty">
+      <p className="text-lg max-w-[38rem] text-pretty">
         Obtenez un <strong>financement</strong> et un{' '}
         <strong>accompagnement</strong> pour travailler avec nous, dans le cadre
         du fonds communs numériques pour La Suite collaborative.
@@ -114,7 +114,7 @@ export const Initiatives = () => (
       </p>
     </ContentSection>
     <ContentSection
-      className="bg-white pt-0 sm:pt-[50px]"
+      className="bg-white text-body pt-0 sm:pt-[50px]"
       classNameChildren="px-0 sm:px-4"
     >
       <div className="hidden md:flex flex-row gap-10">

--- a/src/sections/Initiatives.tsx
+++ b/src/sections/Initiatives.tsx
@@ -13,10 +13,7 @@ const WhiteSquare: React.FC<Omit<CommonProps, 'children'>> = ({
   className,
 }) => (
   <span
-    className={twMerge(
-      'h-[28px] w-[28px] bg-dinum-white-0 absolute z-10',
-      className
-    )}
+    className={twMerge('h-[28px] w-[28px] bg-white-0 absolute z-10', className)}
   />
 )
 
@@ -60,7 +57,7 @@ interface CardProps {
 const Card = ({ title, body, index }: CardProps) => (
   <div
     tabIndex={0}
-    className="bg-dinum-blue-1 text-dinum-white-0 text-left px-6 py-14 sm:p-14 relative focus-visible:m-2 md:basis-1/2"
+    className="bg-blue-1 text-white-0 text-left px-6 py-14 sm:p-14 relative focus-visible:m-2 md:basis-1/2"
   >
     <h3 className="text-3xl font-extrabold mb-7">
       Qu’est ce qu’un <Br /> {title}&nbsp;?
@@ -83,7 +80,7 @@ const data: Omit<CardProps, 'index'>[] = [
 
 export const Initiatives = () => (
   <>
-    <ContentSection className="bg-dinum-white-1 text-left sm:text-center">
+    <ContentSection className="bg-white-1 text-left sm:text-center">
       <h2 className="text-3xl md:text-4xl font-bold max-w-[34rem] text-center">
         Contribuer à La&nbsp;Suite numérique, c’est possible&nbsp;!
       </h2>
@@ -94,7 +91,7 @@ export const Initiatives = () => (
         alt=""
         placeholder="blur"
       />
-      <p className="text-lg text-dinum-grey-1 max-w-[38rem] text-pretty">
+      <p className="text-lg text-grey-1 max-w-[38rem] text-pretty">
         Vous êtes une entité publique ou privée et vous portez une solution
         collaborative structurée sous forme de commun numérique ou de logiciel
         libre ? Vous pouvez intégrer La Suite numérique{' '}
@@ -102,7 +99,7 @@ export const Initiatives = () => (
           pour être utile à des milliers d&apos;agents publics en France&nbsp;!
         </strong>
       </p>
-      <p className="text-lg text-dinum-grey-1 max-w-[38rem] text-pretty">
+      <p className="text-lg text-grey-1 max-w-[38rem] text-pretty">
         Obtenez un <strong>financement</strong> et un{' '}
         <strong>accompagnement</strong> pour travailler avec nous, dans le cadre
         du fonds communs numériques pour La Suite collaborative.
@@ -117,7 +114,7 @@ export const Initiatives = () => (
       </p>
     </ContentSection>
     <ContentSection
-      className="bg-dinum-white-0 pt-0 sm:pt-[50px]"
+      className="bg-white-0 pt-0 sm:pt-[50px]"
       classNameChildren="px-0 sm:px-4"
     >
       <div className="hidden md:flex flex-row gap-10">

--- a/src/sections/Initiatives.tsx
+++ b/src/sections/Initiatives.tsx
@@ -13,7 +13,7 @@ const WhiteSquare: React.FC<Omit<CommonProps, 'children'>> = ({
   className,
 }) => (
   <span
-    className={twMerge('h-[28px] w-[28px] bg-white-0 absolute z-10', className)}
+    className={twMerge('h-[28px] w-[28px] bg-white absolute z-10', className)}
   />
 )
 
@@ -57,7 +57,7 @@ interface CardProps {
 const Card = ({ title, body, index }: CardProps) => (
   <div
     tabIndex={0}
-    className="bg-blue-1 text-white-0 text-left px-6 py-14 sm:p-14 relative focus-visible:m-2 md:basis-1/2"
+    className="bg-blue-1 text-white text-left px-6 py-14 sm:p-14 relative focus-visible:m-2 md:basis-1/2"
   >
     <h3 className="text-3xl font-extrabold mb-7">
       Qu’est ce qu’un <Br /> {title}&nbsp;?
@@ -114,7 +114,7 @@ export const Initiatives = () => (
       </p>
     </ContentSection>
     <ContentSection
-      className="bg-white-0 pt-0 sm:pt-[50px]"
+      className="bg-white pt-0 sm:pt-[50px]"
       classNameChildren="px-0 sm:px-4"
     >
       <div className="hidden md:flex flex-row gap-10">

--- a/src/sections/Newsletter.tsx
+++ b/src/sections/Newsletter.tsx
@@ -8,7 +8,7 @@ export const Newsletter = () => (
         <h2 className="text-[1.375rem] leading-7 font-bold mb-3">
           Recevoir la newsletter de La Suite
         </h2>
-        <p className="text-[.875rem] leading-6 mb-6">
+        <p className="text-[.875rem] text-grey-5 leading-6 mb-6">
           Restez informés des prochaines avancées de La Suite en recevant la
           newsletter !
         </p>

--- a/src/sections/ProConnect.tsx
+++ b/src/sections/ProConnect.tsx
@@ -13,7 +13,7 @@ interface CardProps {
 }
 
 const Card = ({ title, target, text }: CardProps) => (
-  <div className="bg-white-0 p-8 w-full text-left">
+  <div className="bg-white p-8 w-full text-left">
     <h3>
       <span className="font-extrabold text-3xl text-blue-1">{title}</span>
       <Br className="inline" />

--- a/src/sections/ProConnect.tsx
+++ b/src/sections/ProConnect.tsx
@@ -13,15 +13,15 @@ interface CardProps {
 }
 
 const Card = ({ title, target, text }: CardProps) => (
-  <div className="bg-dinum-white-0 p-8 w-full text-left">
+  <div className="bg-white-0 p-8 w-full text-left">
     <h3>
-      <span className="font-extrabold text-3xl text-dinum-blue-1">{title}</span>
+      <span className="font-extrabold text-3xl text-blue-1">{title}</span>
       <Br className="inline" />
-      <span className="text-lg text-dinum-grey-1">
+      <span className="text-lg text-grey-1">
         pour&nbsp;<strong>{target}</strong>
       </span>
     </h3>
-    <p className="mt-8 text-lg text-dinum-grey-1 text-pretty">{text}</p>
+    <p className="mt-8 text-lg text-grey-1 text-pretty">{text}</p>
   </div>
 )
 
@@ -44,12 +44,12 @@ const data: CardProps[] = [
 ]
 
 export const ProConnect = () => (
-  <ContentSection className="bg-dinum-white-1 text-left sm:text-center">
+  <ContentSection className="bg-white-1 text-left sm:text-center">
     <h2 className="px-4 text-3xl md:text-4xl font-bold text-center">
       Connecter tous les intervenants <Br /> de la sphère publique
     </h2>
     <Image src={ProConnectSvg} height={246} width={540} alt="" />
-    <p className="text-lg text-dinum-grey-1 max-w-[44rem]">
+    <p className="text-lg text-grey-1 max-w-[44rem]">
       Le bouton Pro Connect est au cœur de La Suite numérique. <Br />
       Au même titre que France Connect relie les services publics numériques des
       citoyens et citoyennes,{' '}
@@ -59,7 +59,7 @@ export const ProConnect = () => (
       </strong>
     </p>
     <Image src={ProConnectButtonSvg} height={150} width={350} alt="" />
-    <h3 className="text-2xl text-dinum-blue-1 font-bold">
+    <h3 className="text-2xl text-blue-1 font-bold">
       Grâce au bouton Pro Connect, La Suite permet une action&nbsp;…
     </h3>
     <div className="hidden md:flex flex-row gap-3 md:gap-6 max-w-[54em]">

--- a/src/sections/Testimonies.tsx
+++ b/src/sections/Testimonies.tsx
@@ -33,16 +33,14 @@ const Card = ({ title, quote, img, entity }: CardProps) => (
       <Image src={AccountSvg} height={60} width={60} alt="" />
       <p className="font-bold text-grey-2">{title}</p>
     </div>
-    <blockquote className="text-grey-1 leading-6 text-pretty">
-      {quote}
-    </blockquote>
+    <blockquote className="text-body leading-6 text-pretty">{quote}</blockquote>
   </div>
 )
 
 const data: CardProps[] = [
   {
     quote: (
-      <p className="text-grey-1">
+      <p>
         Je suis proviseur adjoint d’une cité scolaire.{' '}
         <strong>
           Tchap est une application respectueuse des données personnelles.
@@ -63,21 +61,25 @@ const data: CardProps[] = [
   },
   {
     quote: (
-      <p className="text-grey-1">
-        Je fais de l’animation de projets inter-collectivités donc j&apos;ai
-        beaucoup de liens avec des partenaires de l’Etat.{' '}
-        <strong>
-          J’utilise Tchap parce que j&apos;étais intéressé par l’open source.
-        </strong>
-        <Br />
-        <Br />
-        Mon prédécesseur avait fait une expérimentation avec quelques
-        collectivités mais nous{' '}
-        <strong>
-          on veut l&apos;utiliser tous les jours, pour l&apos;animation au
-          quotidien des nos communautés.
-        </strong>
-      </p>
+      <>
+        <p>
+          Je fais de l’animation de projets inter-collectivités donc j&apos;ai
+          beaucoup de liens avec des partenaires de l’Etat.{' '}
+          <strong>
+            J’utilise Tchap parce que j&apos;étais intéressé par l’open source.
+          </strong>
+          <Br />
+        </p>
+        <p>
+          <Br />
+          Mon prédécesseur avait fait une expérimentation avec quelques
+          collectivités mais nous{' '}
+          <strong>
+            on veut l&apos;utiliser tous les jours, pour l&apos;animation au
+            quotidien des nos communautés.
+          </strong>
+        </p>
+      </>
     ),
     title: 'Agent de la collectivité territoriale',
     img: AnctSvg,
@@ -86,7 +88,7 @@ const data: CardProps[] = [
   },
   {
     quote: (
-      <p className="text-grey-1">
+      <p>
         Avec la dernière mise à jour de Tchap, on a les{' '}
         <strong>mêmes fonctionnalités qu’avec WhatsApp,</strong> mais en{' '}
         <strong>plus confidentiel.</strong> Bravo !
@@ -100,11 +102,11 @@ const data: CardProps[] = [
 ]
 
 export const Testimonies = () => (
-  <ContentSection className="bg-white-1 text-left sm:text-center">
+  <ContentSection className="bg-white-1 text-body text-left sm:text-center">
     <h2 className="text-3xl md:text-4xl font-bold max-w-[30rem] text-center px-4 ">
       Ils utilisent déjà des applications de La&nbsp;Suite…
     </h2>
-    <p className="text-lg text-grey-1 max-w-[38rem]">
+    <p className="text-lg max-w-[38rem]">
       La Suite est un projet en construction, certaines de ses applications sont
       encore en phase de test, mais{' '}
       <strong>

--- a/src/sections/Testimonies.tsx
+++ b/src/sections/Testimonies.tsx
@@ -31,9 +31,9 @@ const Card = ({ title, quote, img, entity }: CardProps) => (
     </h3>
     <div className="flex flex-row items-center mt-7 gap-4 pb-5">
       <Image src={AccountSvg} height={60} width={60} alt="" />
-      <p className="font-bold text-dinum-grey-2">{title}</p>
+      <p className="font-bold text-grey-2">{title}</p>
     </div>
-    <blockquote className="text-dinum-grey-1 leading-6 text-pretty">
+    <blockquote className="text-grey-1 leading-6 text-pretty">
       {quote}
     </blockquote>
   </div>
@@ -42,7 +42,7 @@ const Card = ({ title, quote, img, entity }: CardProps) => (
 const data: CardProps[] = [
   {
     quote: (
-      <p className="text-dinum-grey-1">
+      <p className="text-grey-1">
         Je suis proviseur adjoint d’une cité scolaire.{' '}
         <strong>
           Tchap est une application respectueuse des données personnelles.
@@ -63,7 +63,7 @@ const data: CardProps[] = [
   },
   {
     quote: (
-      <p className="text-dinum-grey-1">
+      <p className="text-grey-1">
         Je fais de l’animation de projets inter-collectivités donc j&apos;ai
         beaucoup de liens avec des partenaires de l’Etat.{' '}
         <strong>
@@ -86,7 +86,7 @@ const data: CardProps[] = [
   },
   {
     quote: (
-      <p className="text-dinum-grey-1">
+      <p className="text-grey-1">
         Avec la dernière mise à jour de Tchap, on a les{' '}
         <strong>mêmes fonctionnalités qu’avec WhatsApp,</strong> mais en{' '}
         <strong>plus confidentiel.</strong> Bravo !
@@ -100,11 +100,11 @@ const data: CardProps[] = [
 ]
 
 export const Testimonies = () => (
-  <ContentSection className="bg-dinum-white-1 text-left sm:text-center">
+  <ContentSection className="bg-white-1 text-left sm:text-center">
     <h2 className="text-3xl md:text-4xl font-bold max-w-[30rem] text-center px-4 ">
       Ils utilisent déjà des applications de La&nbsp;Suite…
     </h2>
-    <p className="text-lg text-dinum-grey-1 max-w-[38rem]">
+    <p className="text-lg text-grey-1 max-w-[38rem]">
       La Suite est un projet en construction, certaines de ses applications sont
       encore en phase de test, mais{' '}
       <strong>

--- a/src/styles/base-app.css
+++ b/src/styles/base-app.css
@@ -22,5 +22,5 @@ h6 {
 }
 
 strong {
-  @apply text-dinum-grey-2;
+  @apply text-grey-2;
 }

--- a/src/styles/base-app.css
+++ b/src/styles/base-app.css
@@ -21,6 +21,15 @@ h6 {
   overflow-wrap: break-word;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply text-title;
+}
+
 strong {
   @apply text-grey-2;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,6 +56,8 @@ const config: Config = {
     colors: {
       ...figmaColors,
       white: '#FFFFFF',
+      body: figmaColors['grey-1'],
+      title: figmaColors['black-1'],
       dsfr: {
         'blue-1': '#f5f5fe',
         'blue-2': '#1212ff',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ const figmaColors = {
   'grey-0': '#D9D9D9',
   'grey-1': '#7F7E7E',
   'grey-2': '#161616',
-  'grey-3': '#666666',
+  'grey-3': '#4D4D4D',
   'grey-4': '#DDDDDD',
   'grey-5': '#3A3A3A',
   'blue-1': '#000091',
@@ -56,7 +56,7 @@ const config: Config = {
     colors: {
       ...figmaColors,
       white: '#FFFFFF',
-      body: figmaColors['grey-1'],
+      body: figmaColors['grey-3'],
       title: figmaColors['black-1'],
       dsfr: {
         'blue-1': '#f5f5fe',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,28 +41,26 @@ const config: Config = {
       xl: '80em', // 1280px
       '2xl': '96em', // 1536px
     },
+    colors: {
+      'white-0': '#FFFFFF',
+      'white-1': '#F8F8F8',
+      'grey-0': '#D9D9D9',
+      'grey-1': '#7F7E7E',
+      'grey-2': '#161616',
+      'grey-3': '#666666',
+      'grey-4': '#DDDDDD',
+      'grey-5': '#3A3A3A',
+      'blue-1': '#000091',
+      'black-1': '#161616',
+      dsfr: {
+        'blue-1': '#f5f5fe',
+        'blue-2': '#1212ff',
+        'blue-3': '#f3f6fe',
+      },
+    },
     extend: {
       fontFamily: {
         sans: ['var(--font-marianne)', ...defaultTheme.fontFamily.sans],
-      },
-      colors: {
-        dinum: {
-          'white-0': '#FFFFFF',
-          'white-1': '#F8F8F8',
-          'grey-0': '#D9D9D9',
-          'grey-1': '#7F7E7E',
-          'grey-2': '#161616',
-          'grey-3': '#666666',
-          'grey-4': '#DDDDDD',
-          'grey-5': '#3A3A3A',
-          'blue-1': '#000091',
-          'black-1': '#161616',
-        },
-        dsfr: {
-          'blue-1': '#f5f5fe',
-          'blue-2': '#1212ff',
-          'blue-3': '#f3f6fe',
-        },
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,18 @@ import type { Config } from 'tailwindcss'
 
 const defaultTheme = require('tailwindcss/defaultTheme')
 
+const figmaColors = {
+  'white-1': '#F8F8F8',
+  'grey-0': '#D9D9D9',
+  'grey-1': '#7F7E7E',
+  'grey-2': '#161616',
+  'grey-3': '#666666',
+  'grey-4': '#DDDDDD',
+  'grey-5': '#3A3A3A',
+  'blue-1': '#000091',
+  'black-1': '#161616',
+}
+
 const config: Config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -42,16 +54,8 @@ const config: Config = {
       '2xl': '96em', // 1536px
     },
     colors: {
-      'white-0': '#FFFFFF',
-      'white-1': '#F8F8F8',
-      'grey-0': '#D9D9D9',
-      'grey-1': '#7F7E7E',
-      'grey-2': '#161616',
-      'grey-3': '#666666',
-      'grey-4': '#DDDDDD',
-      'grey-5': '#3A3A3A',
-      'blue-1': '#000091',
-      'black-1': '#161616',
+      ...figmaColors,
+      white: '#FFFFFF',
       dsfr: {
         'blue-1': '#f5f5fe',
         'blue-2': '#1212ff',


### PR DESCRIPTION
## Purpose

Match figma design after Johann updates for better contrast ratios, mostly.


## Proposal

Here is some code to match some new colors.

I took the time to, in my point of view, make working with colors easier:

- we don't extend tailwind colors anymore, no risk of using a not intended color in the figma design
- removed the `dinum` color prefix as all our main colors were under this prefix, felt a bit unnecessary for this common case (especially now that default tailwind colors are out)
- added some semantic color tokens to better mark our intentions in the code and ease up future potential color changes (`title` and `body`)