### PR TITLE
💄(testimonies) new content impacting view: scroll through testimonies

### DIFF
--- a/src/components/SwiperWrapper.tsx
+++ b/src/components/SwiperWrapper.tsx
@@ -1,25 +1,25 @@
 import 'swiper/css'
 import 'swiper/css/pagination'
-import { Swiper, SwiperSlide } from 'swiper/react'
+import { Swiper, SwiperProps, SwiperSlide } from 'swiper/react'
 import { Pagination } from 'swiper/modules'
 
 type Slide = any
 
-interface SwiperWrapperProps {
+interface SwiperWrapperProps extends SwiperProps {
   slides: Array<Slide>
-  slidesPerView?: number
 }
 
 export const SwiperWrapper = ({
   slides,
-  slidesPerView = 1,
+  ...swiperProps
 }: SwiperWrapperProps) => {
   return (
     <Swiper
       spaceBetween={50}
-      slidesPerView={slidesPerView}
+      slidesPerView={1}
       pagination={true}
       modules={[Pagination]}
+      {...swiperProps}
     >
       {slides.map((s, i) => (
         <SwiperSlide key={i}>{s}</SwiperSlide>

--- a/src/components/SwiperWrapper.tsx
+++ b/src/components/SwiperWrapper.tsx
@@ -17,7 +17,9 @@ export const SwiperWrapper = ({
     <Swiper
       spaceBetween={50}
       slidesPerView={1}
-      pagination={true}
+      pagination={{
+        clickable: true,
+      }}
       modules={[Pagination]}
       {...swiperProps}
     >

--- a/src/sections/Testimonies.tsx
+++ b/src/sections/Testimonies.tsx
@@ -20,7 +20,10 @@ interface CardProps {
 }
 
 const Card = ({ title, quote, img, entity }: CardProps) => (
-  <div className="flex flex-col bg-white p-7 text-left flex-1 max-w-[36rem] lg:min-w-[18rem]">
+  <div
+    tabIndex={0}
+    className="flex flex-col bg-white p-7 text-left flex-1 max-w-[36rem] lg:min-w-[18rem]"
+  >
     <h3 className="h-[114px] w-[140px] relative">
       <Image
         src={img}

--- a/src/sections/Testimonies.tsx
+++ b/src/sections/Testimonies.tsx
@@ -20,7 +20,7 @@ interface CardProps {
 }
 
 const Card = ({ title, quote, img, entity }: CardProps) => (
-  <div className="flex flex-col bg-white p-7 text-left flex-1">
+  <div className="flex flex-col bg-white p-7 text-left flex-1 max-w-[36rem] lg:min-w-[18rem]">
     <h3 className="h-[114px] w-[140px] relative">
       <Image
         src={img}
@@ -99,6 +99,38 @@ const data: CardProps[] = [
     key: 'interieur',
     entity: "Ministère de l'intérieur",
   },
+  {
+    quote: (
+      <p>
+        Je suis enseignant et dans mon établissement j’ai mis en place le
+        workflow de <strong>RESANA</strong> pour la gestion d’actions qui
+        nécessitent plusieurs étapes de validation, cette GED permet de{' '}
+        <strong>dématérialiser ce processus simplement</strong>.
+      </p>
+    ),
+    title: 'Agent',
+    img: EducationNationaleSvg,
+    key: 'educ-nat-2',
+    entity: "Ministère de l'éducation nationale et de la jeunesse",
+  },
+  {
+    quote: (
+      <p>
+        La <strong>coédition</strong> nous permet de travailler sur des dossiers
+        et partager les documents et ce, même avec des parties prenantes
+        externes.
+        <strong>
+          Je promeus RESANA pour sa facilité de prise en main et l’ensemble des
+          outils disponibles
+        </strong>
+        .
+      </p>
+    ),
+    title: 'Agent',
+    img: EducationNationaleSvg,
+    key: 'educ-nat-4',
+    entity: "Ministère de l'éducation nationale et de la jeunesse",
+  },
 ]
 
 export const Testimonies = () => (
@@ -116,16 +148,17 @@ export const Testimonies = () => (
       <Br />
       Découvrez les applications stars de La Suite :
     </p>
-    <div className="hidden md:flex flex-row gap-7">
-      {data.map((testimony) => (
-        <Card {...testimony} key={testimony.key} />
-      ))}
-    </div>
-    <div className="w-full md:hidden">
+    <div className="w-full">
       <SwiperWrapper
         slides={data.map((testimony) => (
           <Card {...testimony} key={testimony.key} />
         ))}
+        breakpoints={{
+          1024: {
+            slidesPerView: 3,
+            spaceBetween: 28,
+          },
+        }}
       />
     </div>
   </ContentSection>


### PR DESCRIPTION
since we're not sure on the actually wanted layout in figma I just made the wrapping div of testimonies overflow, styled a bit the scrollbar, and made it so that mouse users can "scroll" easily.

i guess this is acceptable for now and we change when we get specific layout info?

https://github.com/numerique-gouv/lasuite-landingpage/assets/221253/c0c42683-77ff-4b3f-a219-7788c6b19e1a


