### PR TITLE
🔥(frontend) remove any mention of Note Pad

### DIFF
--- a/src/sections/Products.tsx
+++ b/src/sections/Products.tsx
@@ -11,7 +11,6 @@ const PRODUCTS_GRID = [
   'Resana',
   'AudioConf',
   'Grist',
-  'Note Pad',
   'Docs',
   'Messagerie',
 ]
@@ -19,7 +18,7 @@ const PRODUCTS_GRID = [
 export const Products = () => {
   return (
     <ContentSection>
-      <div className="flex flex-wrap items-center justify-center xl:grid grid-cols-2 xl:grid-cols-5 gap-8">
+      <div className="grid flex-wrap items-center justify-center  grid-cols-3 gap-8">
         {PRODUCTS_GRID.map((name) => {
           // @ts-ignore
           const hasLink = PRODUCTS[name]?.url

--- a/src/utils/products.tsx
+++ b/src/utils/products.tsx
@@ -122,27 +122,6 @@ export const PRODUCTS: Record<
       </>,
     ],
   },
-  'Note Pad': {
-    displayDetails: true,
-    logo: PadLogo,
-    screenshot: PadScreenshot,
-    name: 'Note Pad',
-    url: 'https://pad.numerique.gouv.fr/',
-    caption:
-      'le meilleur moyen d’écrire et de partager vos notes au format Markdown',
-    description:
-      'Créez, éditez et collaborez en ligne. Tout est sauvegardé automatiquement pour un travail fluide et sécurisé',
-    status: 'BETA',
-    items: [
-      <>
-        <strong>Choisissez la vue</strong> que vous préférez : tout en markdown
-        ou avec l’aperçu final.
-      </>,
-      <>
-        Bénéficiez d’une <strong>correction orthographique</strong>
-      </>,
-    ],
-  },
   Grist: {
     displayDetails: true,
     logo: GristLogo,


### PR DESCRIPTION
My bad, I misunderstood the feedback, all mentions and occurrences of the Note Pad should disappear. Remove it from the home and product pages.

Note: I've adapted the home layout, but it might need a proper redesign.

