### PR TITLE
💄 Display Grist status as in beta

### DIFF
--- a/src/utils/products.tsx
+++ b/src/utils/products.tsx
@@ -177,6 +177,7 @@ export const DINUM_PRODUCTS: Record<
         données
       </>,
     ],
+    status: 'BETA',
   },
   Docs: {
     displayDetails: true,


### PR DESCRIPTION
## Purpose

grist.numerique.gouv.fr is officially in beta and should be displayed as is in the landing page.


## Proposal

Add a `status: "Beta" ` property.