### PR TITLE
💄(grist) add Crisp to Grist landing page

### DIFF
--- a/src/components/HomepageContent.tsx
+++ b/src/components/HomepageContent.tsx
@@ -9,6 +9,7 @@ import { SuiteTerritoriale } from '@/sections/Homepage/SuiteTerritoriale'
 import { FooterLaSuite } from '@/sections/Homepage/FooterLaSuite'
 import FadeInSection from '@/components/FadeInSection'
 import { useEffect } from 'react'
+import { injectCrisp } from '@/utils/inject-crisp'
 
 /**
  * output the homepage content with data taken from the CMS file
@@ -18,16 +19,7 @@ import { useEffect } from 'react'
  */
 export const HomepageContent = () => {
   useEffect(() => {
-    if (!window.$crisp) {
-      window.$crisp = []
-      window.CRISP_WEBSITE_ID = '58ea6697-8eba-4492-bc59-ad6562585041'
-
-      const script = document.createElement('script')
-      script.type = 'text/javascript'
-      script.async = true
-      script.src = 'https://client.crisp.chat/l.js'
-      document.head.appendChild(script)
-    }
+    injectCrisp()
   }, [])
 
   return (

--- a/src/pages/produits/grist.tsx
+++ b/src/pages/produits/grist.tsx
@@ -13,9 +13,15 @@ import { Footer } from '@/sections/produits/grist/Footer'
 import BeforeContactBlockImg from '@/assets/grist/before-contact-block.png'
 import GristLogo from '@/assets/grist/grist-logo-lasuite.svg'
 import Image from 'next/image'
+import { useEffect } from 'react'
+import { injectCrisp } from '@/utils/inject-crisp'
 
 export default function GristLandingPage() {
   const t = useTranslations({ useFallback: true })
+  useEffect(() => {
+    injectCrisp()
+  }, [])
+
   return (
     <Layout
       title={'Grist'}

--- a/src/utils/inject-crisp.ts
+++ b/src/utils/inject-crisp.ts
@@ -1,0 +1,12 @@
+export function injectCrisp() {
+  if (!window.$crisp) {
+    window.$crisp = []
+    window.CRISP_WEBSITE_ID = '58ea6697-8eba-4492-bc59-ad6562585041'
+
+    const script = document.createElement('script')
+    script.type = 'text/javascript'
+    script.async = true
+    script.src = 'https://client.crisp.chat/l.js'
+    document.head.appendChild(script)
+  }
+}


### PR DESCRIPTION
## Purpose

Previously only the La Suite landing page benefited from Crisp. For the Grist Landing page, Crisp would help users to get in touch with the team for their first steps with Grist.

## Proposal

Add Crisp there as well.