### PR TITLE
🎉(home) remove beta status from docs and reorganize product grid

### DIFF
--- a/src/sections/Products.tsx
+++ b/src/sections/Products.tsx
@@ -11,8 +11,8 @@ import { useTranslations } from '@/locales/useTranslations'
 const DINUM_PRODUCTS_GRID = [
   'Tchap',
   'France Transfert',
-  'Grist',
   'Docs',
+  'Grist',
   'Visio',
   'Messagerie',
 ]

--- a/src/utils/products.tsx
+++ b/src/utils/products.tsx
@@ -210,7 +210,6 @@ export const DINUM_PRODUCTS: Record<
       'la solution de prise de notes collaboratives qui vous permet de vous concentrer sur votre contenu',
     description:
       "L'éditeur de texte collaboratif qui privilégie le contenu sur la mise en forme.",
-    status: 'BETA',
     items: [
       <>
         <strong>Invitez vos collègues</strong> ou partagez un lien d'édition


### PR DESCRIPTION
Remove beta designation from docs product and reorganize product grid to display stable products first followed by beta products for consistent product status presentation.
