### PR TITLE
🐛(grist) fix bug that prevented grist contact form submission

### DIFF
--- a/src/components/ui-kit-v2/Button.tsx
+++ b/src/components/ui-kit-v2/Button.tsx
@@ -31,6 +31,7 @@ interface ButtonProps {
   className?: string
   style?: React.CSSProperties
   onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
+  type?: 'button' | 'submit' | 'reset'
 }
 
 const transition = 'transition ease-in-out delay-50 duration-300'
@@ -76,6 +77,7 @@ export const Button: React.FC<ButtonProps> = ({
   className,
   style,
   onClick,
+  type = 'button',
 }) => {
   const t = useTranslations()
   const normalizedVariant = (variant as string) || 'primary_brand'
@@ -152,7 +154,7 @@ export const Button: React.FC<ButtonProps> = ({
       aria-label={finalAriaLabel}
       style={inlineStyle}
       onClick={onClick}
-      type="button"
+      type={type}
     >
       {content}
     </button>

--- a/src/sections/produits/grist/Contact.tsx
+++ b/src/sections/produits/grist/Contact.tsx
@@ -128,7 +128,9 @@ export const Contact = () => {
             errors={errors.message}
           />
           <div className="w-full md:w-fit md:ml-auto md:mx-auto">
-            <Button fullWidth>{t('common.send')}</Button>
+            <Button fullWidth type="submit">
+              {t('common.send')}
+            </Button>
           </div>
         </form>
       ) : (


### PR DESCRIPTION
Fix a bug introduced in 8c90055 that forced every button to `button` type, making the submit button used in the grist contact form not doing anything anymore.

(pouet @elvoisin just so you know)