### PR TITLE
✨(legal) add Docs legal pages and FAQ links on landing

### DIFF
--- a/content/legal-docs-pages/en/donnees-personnelles-cookies.yml
+++ b/content/legal-docs-pages/en/donnees-personnelles-cookies.yml
@@ -1,0 +1,88 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: donnees-personnelles-cookies
+title: Personal Data and Cookies - Docs
+body: |
+  ## Docs Privacy Policy
+
+  ### Who is responsible for Docs?
+
+  The Docs site is developed within the DINUM. Docs is an online text editor that allows its users to co-edit text documents and export them.
+
+  The data controller is the Interministerial Directorate for Digital Affairs (DINUM), represented by Madame Stéphanie Schaer, Interministerial Director for Digital Affairs.
+
+  ### Why and how are your personal data processed?
+
+  | Data | Purpose pursued | Legal basis | Retention period | Recipients |
+  | --- | --- | --- | --- | --- |
+  | Email | Notify the user when they are invited to a document and to connect to ProConnect | Public interest mission within the competence of the DINUM (Article 6 - 11° of Decree No. 2019-1088 of October 25, 2019) | Until the user deletes their account | DINUM |
+  | First and last name | Allow to display who collaborates/creates documents on the platform | Public interest mission within the competence of the DINUM (Article 6 - 11° of Decree No. 2019-1088 of October 25, 2019) | Until the user deletes their account | DINUM |
+
+  ### Who helps us process your personal data?
+
+  In order to host your personal data or perform audience measurement, we use a subcontractor. Before transmitting your data to them, we ensured that they implemented adequate guarantees and respected strict conditions of confidentiality, use and data protection.
+
+  | Partners | Recipient country | Processing performed | Guarantees |
+  | --- | --- | --- | --- |
+  | IndieHosters | France | Kubernetes cluster administration | Subcontracting clauses |
+  | Outscale | France | Hosting | Subcontracting clauses |
+  | Posthog | Germany | Audience measurement | Subcontracting clauses |
+  | Crisp | France | User support/surveys, new version announcements | Subcontracting clauses |
+
+  ### What security measures do we implement?
+
+  We implement several measures to secure the data:
+
+  * Storage with the Outscale host in SecNumCloud on the Kubernetes cluster of La Suite Numérique, which respects the best practices in hosting and server administration;
+
+  * Implementation of a bug bounty program to ensure security;
+
+  * Anti-DDOS protection and Web Application Firewall;
+
+  * Security homologation by the DINUM's RSSI.
+
+  ### What are your rights?
+
+  You have:
+
+  * a right to information and a right to access your data;
+
+  * a right to limit the processing of your data;
+
+  * a right to rectification;
+
+  * a right to object.
+
+  To exercise these rights, contact us by email: [dpd@pm.gouv.fr](mailto:dpd@pm.gouv.fr)
+
+  Or by mail to the following address:
+
+  Services du Premier ministre
+  À l'attention du délégué à la protection des données (DPD)
+  56 rue de Varenne
+  75007 Paris
+
+  Since these are personal rights, we will only process your request if we are able to identify you. In case we are unable to identify you, we may ask you for proof of your identity.
+
+  To help you with your request, you can find a template developed by the CNIL here: <https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces>
+
+  We undertake to respond to you within a reasonable time frame that will not exceed 1 month from the receipt of your request.
+
+  ## Audience tracking and privacy
+
+  ### Cookies and opt-out
+
+  This site deposits a small text file (a "cookie") on your device when you visit it.
+
+  We deposit a session cookie that allows you to remain authenticated to Docs as long as your ProConnect session is active.
+
+  We also use Crisp for user support and to notify new versions.
+
+  Posthog, an open-source audience measurement tool, provides us with statistical data such as the number of visits and to understand which pages are the most consulted in order to continuously improve the product.
+
+  ### Why does this site not display a cookie consent banner?
+
+  We simply respect the law, which states that certain audience tracking tools, properly configured to respect privacy, are exempt from prior authorization.

--- a/content/legal-docs-pages/en/mentions-legales.yml
+++ b/content/legal-docs-pages/en/mentions-legales.yml
@@ -1,0 +1,53 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: mentions-legales
+title: Legal Notice - Docs
+body: |
+  ## Publisher
+
+  The Docs site is published by the Interministerial Directorate of Digital Affairs (DINUM) located at:
+
+  20 Avenue de Ségur
+  75007 Paris
+  Phone: 01.71.21.01.70
+  SIRET: 12000101100010 (General Secretariat of the Government)
+  SIREN: 120 001 011
+
+  ## Publishing Director
+
+  The publishing director is Mrs. Stéphanie Schaer, Interministerial Director of Digital Affairs.
+
+  ## Hosting of the platform
+
+  The platform is hosted by Outscale, located:
+
+  1, rue Royale – 319 Bureaux de la Colline 92210 Saint-Cloud
+
+  ## Accessibility
+
+  The platform is partially accessible.
+
+  ## Learn more
+
+  To learn more about the State's digital accessibility policy: <https://accessibilite.numerique.gouv.fr/>
+
+  ## Security
+
+  The platform is protected by an electronic certificate, materialized for most browsers by a padlock. This protection contributes to the confidentiality of exchanges.
+
+  Under no circumstances will the services associated with the platform be the origin of sending emails to request the entry of personal information.
+
+  ## Reuse of content
+
+  Unless explicitly stated, the intellectual property held by third parties, the content of this site is offered under [Etalab Open License 2.0](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf).
+
+  You are free to reproduce, copy, modify, extract, transform, communicate, disseminate, redistribute, publish, transmit and exploit the content, provided that you mention its source, date of last update and do not mislead third parties as to the information it contains.
+
+  Any public or private site is authorized to establish, without prior authorization, a link (including deep) to the information disseminated on this site.
+
+  ## Contact
+
+  The email address for contact is: [lasuite@numerique.gouv.fr](mailto:lasuite@numerique.gouv.fr)

--- a/content/legal-docs-pages/en/modalite-utilisation.yml
+++ b/content/legal-docs-pages/en/modalite-utilisation.yml
@@ -76,6 +76,7 @@ body: |
 
   These changes are notified to the user.
 
+
   These changes and updates are imposed on the user who must, therefore, regularly refer to this section to check the general conditions in force.
 
   ## Accessibility
@@ -84,4 +85,4 @@ body: |
 
   ### Compliance Status
 
-  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** is partially compliant with RGAA 4.1. The site was first audited in April 2026; the audit report is available [here](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).
+  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** is partially compliant with RGAA 4.1. The site was first audited in May 2026, the declaration issued on 12/05/2026 is accessible [via this link](/legal/docs/declaration-accessibilite), the audit report [here](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).

--- a/content/legal-docs-pages/en/modalite-utilisation.yml
+++ b/content/legal-docs-pages/en/modalite-utilisation.yml
@@ -1,0 +1,87 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: modalite-utilisation
+title: Terms of Use - Docs
+body: |
+  ## Scope
+
+  This document defines the terms of use for Docs, an online text editor that allows users to co-edit text documents and export them.
+
+  ## Purpose of the Platform
+
+  The service allows users to edit text documents online alone or with others and export them.
+
+  Docs is developed and operated by the DINUM.
+
+  Any use of this service must comply with these terms of use.
+
+  ## Access to the Service
+
+  Docs is accessible at [docs.numerique.gouv.fr](https://docs.numerique.gouv.fr).
+
+  Docs is made available to ProConnect users.
+
+  The use of the service is free and free of charge, but creating an account on the platform is necessary to create a document.
+
+  ## Features
+
+  The user can log in with ProConnect, create text documents, export them, and invite other users to co-edit them.
+
+  ## User Commitments and Responsibilities
+
+  ### Compliant Uses
+
+  The user is responsible for the data or content they enter into Docs. They must ensure that they only enter appropriate messages.
+
+  ### Prohibited Uses
+
+  The user agrees not to enter into Docs any content or information that is contrary to applicable laws and regulations.
+
+  It is recalled that any person who makes a false declaration for themselves or for others is exposed, in particular, to the sanctions provided for in Article 441-1 of the Penal Code, which provides for penalties of up to three years' imprisonment and a fine of 45,000 euros.
+
+  ### Use of Artificial Intelligence Service
+
+  Docs provides an artificial intelligence service based on [Albert API](https://alliance.numerique.gouv.fr/albert/), a service deployed by the DINUM to provide generative AI models and services to products with impact developed in the French administration.
+
+  This artificial intelligence service is designed to facilitate writing, synthesis, layout, and translation.
+
+  This service is not intended to generate individual administrative decisions intended for the public.
+
+  The user must approach their administration to ensure the framework for using a device of this type for text writing.
+
+  ## DINUM Commitments and Responsibilities
+
+  ### Security and Access to the Platform
+
+  The DINUM undertakes to secure Docs, in particular by taking all necessary measures to guarantee the security and confidentiality of the information provided.
+
+  The DINUM undertakes to provide the necessary and reasonable means to ensure continuous access to Docs.
+
+  The DINUM reserves the right to evolve, modify or suspend, without notice, the service for maintenance reasons or for any other reason deemed necessary.
+
+  The DINUM reserves the right to suspend or delete a user account that has not complied with these terms of use, without prejudice to any criminal or civil proceedings that may be brought against the user.
+
+  ### Open Source and Licenses
+
+  The source code of Docs is free and available here: <https://github.com/suitenumerique/docs>
+
+  The content offered by the DINUM is under Open License, except for logos and iconographic and photographic representations which may be governed by their own licenses.
+
+  ## Evolution of Terms of Use
+
+  The terms of these terms of use may be modified or supplemented at any time, without notice, depending on the changes made to the service, the evolution of the legislation or for any other reason deemed necessary.
+
+  These changes are notified to the user.
+
+  These changes and updates are imposed on the user who must, therefore, regularly refer to this section to check the general conditions in force.
+
+  ## Accessibility
+
+  **DINUM - OPI - LaSuite** undertakes to make its digital services accessible, in accordance with Article 47 of Law No. 2005-102 of February 11, 2005.
+
+  ### Compliance Status
+
+  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** is partially compliant with RGAA 4.1. The site was first audited in April 2026; the audit report is available [here](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).

--- a/content/legal-docs-pages/fr/declaration-accessibilite.yml
+++ b/content/legal-docs-pages/fr/declaration-accessibilite.yml
@@ -1,0 +1,142 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: false
+  nl: false
+slug: declaration-accessibilite
+title: Déclaration d'accessibilité - Docs
+body: |
+  **OPI - La Suite numérique** s'engage à rendre ses sites internet, intranet, extranet et ses progiciels accessibles (et ses applications mobiles et mobilier urbain numérique) conformément à l'article 47 de la loi n° 2005-102 du 11 février 2005.
+
+  Cette déclaration d'accessibilité s'applique à **https://lasuite.numerique.gouv.fr/produits/docs**.
+
+  ## État de conformité
+
+  **Docs [https://lasuite.numerique.gouv.fr/produits/docs](https://lasuite.numerique.gouv.fr/produits/docs)** *(nouvelle fenêtre)* est **partiellement conforme** avec le référentiel général d'amélioration de l'accessibilité (RGAA).
+
+  ### Résultats des tests
+
+  L'audit de conformité réalisé par **DINUM - Pôle Accessibilité et Design** révèle que **63 %** des critères du RGAA version 4.1.2 sont respectés.
+
+  ## Contenus non accessibles
+
+  ### Non-conformités
+
+  **Les personnes aveugles et malvoyantes qui utilisent un clavier et/ou une synthèse vocale ne peuvent pas actuellement lire, éditer ou contribuer.**
+
+  * Les images informatives n'ont pas toujours une alternative textuelle ;
+
+  * Les images décoratives ne sont pas toutes ignorées par les aides techniques ;
+
+  * Les ratios de contrastes peuvent être insuffisants en fonction de la combinaison de couleurs proposées ;
+
+  * Certains liens et boutons ne sont pas explicites ou n'ont pas de nom accessible ne sont pas atteignables au clavier ou avec un lecteur d'écran ;
+
+  * Les messages d'état ne sont pas restitués aux aides techniques ;
+
+  * L'ordre de tabulation n'est pas toujours cohérent y compris dans les modales ;
+
+  * Les changements de langue ne sont pas toujours corrects ;
+
+  * Des balises sont utilisées à des fins de présentation ;
+
+  * Les titres et les balises ne sont pas toujours correctement structurées ;
+
+  * Les étiquettes de formulaires sont parfois pas pertinentes ;
+
+  * Il y a une perte d'information sur le contenu quand la page est zoomée à 200% ;
+
+  * Les documents bureautiques téléchargeables ne sont pas accessibles ;
+
+  * Le titre de la page n'est pas toujours pertinent ;
+
+  * Les vidéos n'ont pas de transcription textuelle, ni de sous-titres s'il y a du son ;
+
+  * Les cadres n'ont pas de titre.
+
+  #### Éditeur
+
+  * Certaines fonctionnalités de l'éditeur ne permettent pas d'utiliser un clavier ou avec un lecteur d'écran ;
+
+  * L'éditeur ne permet pas l'ajout d'alternative textuelle, ni de titre de tableau et d'associer certaines cellules à des entêtes ainsi que l'ajout de la langue sur un passage non traduit ;
+
+  * L'écriture collaborative n'est pas compatible avec les lecteurs d'écran.
+
+  ## Établissement de cette déclaration d'accessibilité
+
+  Cette déclaration a été établie le 12 mai 2026.
+
+  ### Technologies utilisées pour la réalisation de l'audit
+
+  * HTML
+
+  * CSS
+
+  * Javascript
+
+  * Django
+
+  * BlockNote React
+
+  * React (Next)
+
+  ### Environnement de test
+
+  Les vérifications de restitution de contenus ont été réalisées sur la base de la combinaison fournie par la base de référence du RGAA, avec les versions suivantes :
+
+  * Sur Ordinateur MacOS avec Safari et VoiceOver
+
+  * Sur Ordinateur Windows avec Firefox et JAWS
+
+  * Sur Ordinateur Windows avec Firefox et NVDA
+
+  ### Outils pour évaluer l'accessibilité
+
+  * Web Developer Toolbar
+
+  * Colour Contrast Analyser
+
+  * HeadingsMap
+
+  * ArcToolkit
+
+  * Inspecteur de composants
+
+  * Validateur HTML du W3C
+
+  ### Pages du site ayant fait l'objet de la vérification de conformité
+
+  * Accueil (non connecté) - Présentation du produit **https://docs.numerique.gouv.fr/**
+
+  * Tunnel de connexion (ProConnect) **https://auth.agentconnect.gouv.fr/api/v2/interaction/COkaeTNIoZmSbp93mRdB3**
+
+  * Accueil (connecté) - Docs **https://docs.numerique.gouv.fr/**
+
+  * Page mise en forme **https://docs.numerique.gouv.fr/docs/16cd8c6a-4965-4bff-bb30-e466fd4d9f3e/**
+
+  * Page Tableaux **https://docs.numerique.gouv.fr/docs/0d998bef-1b69-47ce-bd18-83d4d849c734/**
+
+  * Page Sauts de page **https://docs.numerique.gouv.fr/docs/fcfa6f78-1fd6-4e15-8efe-47a5d881c67f/**
+
+  * Page données personnelles **https://docs.numerique.gouv.fr/docs/eb863389-a5e5-4d18-879d-149a1122380e/**
+
+  ## Retour d'information et contact
+
+  Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de Docs pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+
+  * Contacter **OPI - La Suite numérique : [lasuite@numerique.gouv.fr](mailto:lasuite@numerique.gouv.fr)**
+
+  ## Voies de recours
+
+  Si vous constatez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.
+
+  Plusieurs moyens sont à votre disposition :
+
+  * [Écrire un message au Défenseur des droits](https://formulaire.defenseurdesdroits.fr/formulaire_saisine)
+
+  * [Contacter le délégué du Défenseur des droits dans votre région](https://www.defenseurdesdroits.fr/carte-des-delegues)
+
+  * Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) à :
+    Défenseur des droits
+    Libre réponse 71120
+    75342 Paris CEDEX 07

--- a/content/legal-docs-pages/fr/donnees-personnelles-cookies.yml
+++ b/content/legal-docs-pages/fr/donnees-personnelles-cookies.yml
@@ -1,0 +1,88 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: donnees-personnelles-cookies
+title: Données personnelles et cookies - Docs
+body: |
+  ## Politique de confidentialité de Docs
+
+  ### Qui est responsable de Docs ?
+
+  Le site de Docs est développé au sein de la DINUM. Docs est un éditeur de texte en ligne permettant à ses utilisateurs de co-éditer des documents textes et de les exporter.
+
+  Le responsable du traitement des données est la Direction interministérielle du numérique de l'Etat (DINUM), représentée par Madame Stéphanie Schaer, Directrice interministérielle du numérique.
+
+  ### Pourquoi et comment vos données personnelles sont traitées ?
+
+  | Données | Finalité poursuivie | Fondement juridique | Durée de conservation | Destinataires |
+  | --- | --- | --- | --- | --- |
+  | Courriel | Notifier l'utilisateur quand il est invité sur un document et pour se connecter à ProConnect | Mission d'intérêt public relevant de la compétence de la DINUM (article 6 – 11° du décret n° 2019-1088 du 25 octobre 2019) | Jusqu'à suppression du compte par l'utilisateur | DINUM |
+  | Nom et prénom | Permet d'afficher qui collabore / crée des documents sur la plateforme | Mission d'intérêt public relevant de la compétence de la DINUM (article 6 – 11° du décret n° 2019-1088 du 25 octobre 2019) | Jusqu'à suppression du compte par l'utilisateur | DINUM |
+
+  ### Qui nous aide à traiter vos données personnelles ?
+
+  Afin d'héberger vos données personnelles ou réaliser de la mesure d'audience, nous faisons appel à un sous-traitant. Avant de lui transmettre vos données, nous nous sommes assurés de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d'usage et de protection des données.
+
+  | Partenaires | Pays destinataire | Traitement réalisé | Garanties |
+  | --- | --- | --- | --- |
+  | IndieHosters | France | Administration du cluster Kubernetes | Clauses de sous-traitance |
+  | Outscale | France | Hébergement | Clauses de sous-traitance |
+  | Posthog | Allemagne | Mesure d'audience | Clauses de sous-traitance |
+  | Crisp | France | Support / enquêtes utilisateur, annonce nouvelle versions | Clauses de sous-traitance |
+
+  ### Quelles mesures de sécurité mettons-nous en place ?
+
+  Nous mettons en place plusieurs mesures pour sécuriser les données :
+
+  * Stockage chez l'hébergeur Outscale en SecNumCloud sur le cluster Kubernetes de La Suite Numérique qui respecte les meilleurs pratiques en matière d'hébergement et d'administration serveur ;
+
+  * Organisation de programme de prime à la faille détectée (*bug bounty*) pour assurer la sécurité ;
+
+  * Protection anti-DDOS et Web Application Firewall ;
+
+  * Homologation de sécurité par les RSSI de la DINUM.
+
+  ### Quels sont vos droits ?
+
+  Vous disposez :
+
+  * d'un droit d'information et d'un droit d'accès à vos données ;
+
+  * d'un droit à la limitation du traitement de vos données ;
+
+  * d'un droit de rectification ;
+
+  * d'un droit d'opposition.
+
+  Pour les exercer, contactez-nous par message électronique : [dpd@pm.gouv.fr](mailto:dpd@pm.gouv.fr)
+
+  Ou par voie postale à l'adresse suivante :
+
+  Services du Premier ministre
+  À l'attention du délégué à la protection des données (DPD)
+  56 rue de Varenne
+  75007 Paris
+
+  Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure de vous identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être amenés à vous demander une preuve de votre identité.
+
+  Pour vous aider dans votre démarche, vous trouverez un modèle de demande élaboré par la CNIL ici : <https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces>
+
+  Nous nous engageons à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+
+  ## Suivi d'audience et vie privée
+
+  ### Cookies déposés et opt-out
+
+  Ce site dépose un petit fichier texte (un « cookie ») sur votre appareil lorsque vous le consultez.
+
+  Nous déposons un cookie de session qui vous permet de rester authentifier à Docs tant que votre session ProConnect est active.
+
+  Nous utilisons également Crisp pour le support utilisateur et notifier des nouveautés apportées par chaque nouvelles versions.
+
+  Posthog, un outil de mesure d'audience open source, nous fournit des mesures statistiques comme le nombre de visites et de comprendre quelles sont les pages les plus consultées afin que nous puissions améliorer le produit en continu.
+
+  ### Ce site n'affiche pas de bannière de consentement aux cookies, pourquoi ?
+
+  Nous respectons simplement la loi, qui dit que certains outils de suivi d'audience, correctement configurés pour respecter la vie privée, sont exemptés d'autorisation préalable.

--- a/content/legal-docs-pages/fr/mentions-legales.yml
+++ b/content/legal-docs-pages/fr/mentions-legales.yml
@@ -1,0 +1,53 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: mentions-legales
+title: Mentions légales - Docs
+body: |
+  ## Éditeur
+
+  Le site Docs est édité par la Direction interministérielle du numérique de l'Etat (DINUM) située :
+
+  20 avenue de Ségur
+  75007 Paris
+  Tel. Accueil : 01.71.21.01.70
+  SIRET : 12000101100010 (secrétariat général du gouvernement)
+  SIREN : 120 001 011
+
+  ## Directeur de la publication
+
+  La directrice de la publication est Madame Stéphanie Schaer, Directrice interministérielle du numérique.
+
+  ## Hébergement de la plateforme
+
+  La plateforme est hébergée par Outscale, situé :
+
+  1, rue Royale – 319 Bureaux de la Colline 92210 Saint-Cloud
+
+  ## Accessibilité
+
+  La plateforme est partiellement accessible.
+
+  ## En savoir plus
+
+  Pour en savoir plus sur la politique d'accessibilité numérique de l'État : <https://accessibilite.numerique.gouv.fr/>
+
+  ## Sécurité
+
+  La plateforme est protégée par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges.
+
+  En aucun cas les services associés à la plateforme ne seront à l'origine d'envoi de courriels pour demander la saisie d'informations personnelles.
+
+  ## Réutilisation des contenus
+
+  Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous [licence ouverte Etalab 2.0](https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf).
+
+  Vous êtes notamment libres de les reproduire, copier, modifier, extraire, transformer, communiquer diffuser, redistribuer, publier, transmettre et exploiter sous réserve de mentionner leur source, leur date de dernière mise à jour et ne pas induire en erreur des tiers quant aux informations qui y figurent.
+
+  Tout site public ou privé est autorisé à établir, sans autorisation préalable, un lien (y compris profond) vers les informations diffusées sur ce site.
+
+  ## Contact
+
+  L'adresse courriel de contact est la suivante : [lasuite@numerique.gouv.fr](mailto:lasuite@numerique.gouv.fr)

--- a/content/legal-docs-pages/fr/modalite-utilisation.yml
+++ b/content/legal-docs-pages/fr/modalite-utilisation.yml
@@ -1,0 +1,87 @@
+enabled: true
+enabled_i18n:
+  de: false
+  en: true
+  nl: false
+slug: modalite-utilisation
+title: Modalités d'utilisation - Docs
+body: |
+  ## Champ d'application
+
+  Le présent document définit les modalités d'utilisation de Docs, un éditeur de texte en ligne permettant à ses utilisateurs de co-éditer des documents textes et de les exporter.
+
+  ## Objet de la plateforme
+
+  Le service permet d'éditer des documents textes en ligne seul ou à plusieurs et de les exporter.
+
+  Docs est développé et opéré par la DINUM.
+
+  Toute utilisation de ce service doit respecter les présentes modalités d'utilisation.
+
+  ## Accès au service
+
+  Docs est accessible sur [docs.numerique.gouv.fr](https://docs.numerique.gouv.fr).
+
+  Docs est mis à disposition aux utilisateurs de ProConnect.
+
+  L'utilisation du service est libre et gratuite, pour créer un document il est nécessaire de créer un compte sur la plateforme.
+
+  ## Fonctionnalités
+
+  L'utilisateur ou l'utilisatrice peut se connecter par ProConnect, créer des documents texte, les exporter et inviter d'autres utilisateurs ou utilisatrices à les co-éditer.
+
+  ## Engagements et responsabilités des utilisateurs et utilisatrices
+
+  ### Usages conformes
+
+  L'utilisateur ou l'utilisatrice est responsable des données ou contenus qu'il ou elle saisit dans Docs. Il ou elle veille à ne saisir que des messages appropriés.
+
+  ### Usages interdits
+
+  L'utilisateur ou l'utilisatrice s'engage à ne pas saisir dans Docs des contenus ou informations contraires aux dispositions légales et réglementaires en vigueur.
+
+  Il est rappelé que toute personne qui procède à une fausse déclaration pour elle-même ou pour autrui s'expose, notamment, aux sanctions prévues à l'article 441-1 du Code pénal, prévoyant des peines pouvant aller jusqu'à trois ans d'emprisonnement et 45 000 euros d'amende.
+
+  ### Utilisation du service d'intelligence artificielle
+
+  Docs met à disposition un service d'intelligence artificielle reposant sur [Albert API](https://alliance.numerique.gouv.fr/albert/), un service déployé par la DINUM visant à fournir des modèles et services d'IA générative aux produits à impact développés dans l'administration française.
+
+  Ce service d'intelligence artificielle a vocation à faciliter la rédaction, la synthèse, la mise en page et la traduction.
+
+  Ce service n'a pas vocation à générer des décisions administratives individuelles destinées au public.
+
+  L'utilisateur ou l'utilisatrice doit se rapprocher de son administration pour s'assurer du cadre d'utilisation en son sein d'un dispositif de ce type pour la rédaction de texte.
+
+  ## Engagements et responsabilités de la DINUM
+
+  ### Sécurité et accès à la Plateforme
+
+  La DINUM s'engage à la sécurisation de Docs, notamment en prenant toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité des informations fournies.
+
+  La DINUM s'engage à fournir les moyens nécessaires et raisonnables pour assurer un accès continu à Docs.
+
+  La DINUM se réserve le droit de faire évoluer, de modifier ou de suspendre, sans préavis, le service pour des raisons de maintenance ou pour tout autre motif jugé nécessaire.
+
+  La DINUM se réserve le droit de suspendre ou supprimer un compte utilisateur ou utilisatrice du service qui aurait méconnu les présentes modalités d'utilisation, sans préjudice des éventuelles actions en responsabilité pénale et civile qui pourraient être engagées à l'encontre de l'utilisateur ou l'utilisatrice.
+
+  ### Open Source et Licences
+
+  Le code source de Docs est libre et disponible ici : <https://github.com/suitenumerique/docs>
+
+  Les contenus proposés par la DINUM sont sous Licence Ouverte, à l'exception des logos et des représentations iconographiques et photographiques pouvant être régis par leurs licences propres.
+
+  ## Évolution des modalités d'utilisation
+
+  Les termes des présentes modalités d'utilisation peuvent être modifiés ou complétés à tout moment, sans préavis, en fonction des modifications apportées au service, de l'évolution de la législation ou pour tout autre motif jugé nécessaire.
+
+  Ces modifications sont notifiées à l'utilisateur ou l'utilisatrice.
+
+  Ces modifications et mises à jour s'imposent à l'utilisateur ou l'utilisatrice qui doit, en conséquence, se référer régulièrement à cette rubrique pour vérifier les conditions générales en vigueur.
+
+  ## Accessibilité
+
+  La **DINUM - OPI - LaSuite** s'engage à rendre accessibles ses services numériques, conformément à l'article 47 de la loi n° 2005-102 du 11 février 2005.
+
+  ### État de conformité
+
+  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** est partiellement conforme avec le RGAA 4.1. Le site a été audité pour la première fois en avril 2026 ; le rapport d'audit est accessible [ici](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).

--- a/content/legal-docs-pages/fr/modalite-utilisation.yml
+++ b/content/legal-docs-pages/fr/modalite-utilisation.yml
@@ -84,4 +84,4 @@ body: |
 
   ### État de conformité
 
-  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** est partiellement conforme avec le RGAA 4.1. Le site a été audité pour la première fois en avril 2026 ; le rapport d'audit est accessible [ici](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).
+  **[docs.numerique.gouv.fr](https://docs.numerique.gouv.fr)** est partiellement conforme avec le RGAA 4.1. Le site a été audité pour la première fois en mai 2026, la déclaration établie le 12/05/2026 est accessible [sur ce lien](/legal/docs/declaration-accessibilite), le rapport d'audit [ici](https://ara.numerique.gouv.fr/rapport/NQm_a0q0oJUVhg9_jVjUE/).

--- a/src/cms/collections/index.ts
+++ b/src/cms/collections/index.ts
@@ -1,5 +1,6 @@
 import { collection as servicePageCollection } from './service-page'
 import { collection as contentPageCollection } from './content-page'
+import { collection as legalDocsPageCollection } from './legal-docs-page'
 import { FileCollection, FolderCollection } from '@/cms/types'
 
 const collections: {
@@ -7,7 +8,11 @@ const collections: {
   folderCollections: FolderCollection<any>[]
 } = {
   fileCollections: [],
-  folderCollections: [servicePageCollection, contentPageCollection],
+  folderCollections: [
+    servicePageCollection,
+    contentPageCollection,
+    legalDocsPageCollection,
+  ],
 }
 
 export default collections

--- a/src/cms/collections/legal-docs-page.tsx
+++ b/src/cms/collections/legal-docs-page.tsx
@@ -1,0 +1,74 @@
+import type { CmsCollection } from 'decap-cms-core'
+import { toHtml } from '@/utils/markdown'
+import { PageContent } from '@/components/PageContent'
+import { createCollection } from '../createCollection'
+import { Raw } from '@/components/Raw'
+import { i18n } from '../commonFields'
+import type { I18nField } from '../types'
+
+const config: CmsCollection = {
+  label: 'Pages légales Docs',
+  label_singular: 'Page légale Docs',
+  name: 'legal-docs-page',
+  identifier_field: 'title',
+  slug: '{{fields.slug}}',
+  format: 'yml',
+  folder: 'content/legal-docs-pages',
+  preview_path: '/legal/docs/{{id}}',
+  i18n: true,
+  create: true,
+  fields: [
+    {
+      label: 'Page activée ?',
+      hint: 'Décocher cette case rendra la page inaccessible sur le site',
+      name: 'enabled',
+      widget: 'boolean',
+      required: false,
+      default: true,
+    },
+    i18n(),
+    {
+      label: 'slug',
+      hint: 'URL slug pour /legal/docs/{slug}',
+      name: 'slug',
+      widget: 'string',
+    },
+    {
+      label: 'Titre de la page',
+      name: 'title',
+      widget: 'string',
+      i18n: true,
+    },
+    {
+      label: 'Contenu',
+      name: 'body',
+      widget: 'markdown',
+      i18n: true,
+    },
+  ],
+}
+
+export type EntrySchema = I18nField & {
+  enabled: boolean
+  slug: string
+  title: string
+  body: string
+}
+
+const entryParser = async (json: EntrySchema) => {
+  const data = structuredClone(json)
+  data.body = await toHtml(data.body)
+  return data
+}
+
+const entryPreview = (data: EntrySchema) => (
+  <PageContent title={data.title}>
+    <Raw>{data.body}</Raw>
+  </PageContent>
+)
+
+export const collection = createCollection<EntrySchema>({
+  config,
+  entryParser,
+  entryPreview,
+})

--- a/src/content/products/docs.json
+++ b/src/content/products/docs.json
@@ -195,6 +195,10 @@
         {
           "q": "Puis-je exporter mes Docs en format Word, PDF ou ODT ?",
           "a": "Oui, vous pouvez exporter votre fichier en Word, PDF ou ODT."
+        },
+        {
+          "q": "Où puis-je consulter les informations légales (accessibilité, données personnelles etc.) concernant LaSuite Docs ?",
+          "a": "Voici la liste des pages que vous pouvez consulter :<br>- <a href=\"/legal/docs/donnees-personnelles-cookies\">Données personnelles et cookies</a><br>- <a href=\"/legal/docs/modalite-utilisation\">Modalité d'utilisation et accessibilité</a><br>- <a href=\"/legal/docs\">Mentions légales</a>"
         }
       ],
       "links": [

--- a/src/content/products/docs.json
+++ b/src/content/products/docs.json
@@ -198,7 +198,7 @@
         },
         {
           "q": "Où puis-je consulter les informations légales (accessibilité, données personnelles etc.) concernant LaSuite Docs ?",
-          "a": "Voici la liste des pages que vous pouvez consulter :<br>- <a href=\"/legal/docs/donnees-personnelles-cookies\">Données personnelles et cookies</a><br>- <a href=\"/legal/docs/modalite-utilisation\">Modalité d'utilisation et accessibilité</a><br>- <a href=\"/legal/docs\">Mentions légales</a>"
+          "a": "Voici la liste des pages que vous pouvez consulter :<br>- <a href=\"/legal/docs/donnees-personnelles-cookies\">Données personnelles et cookies</a><br>- <a href=\"/legal/docs/modalite-utilisation\">Modalité d'utilisation</a><br>- <a href=\"/legal/docs/declaration-accessibilite\">Déclaration d'accessibilité</a><br>- <a href=\"/legal/docs\">Mentions légales</a>"
         }
       ],
       "links": [

--- a/src/pages/legal/docs/[slug].tsx
+++ b/src/pages/legal/docs/[slug].tsx
@@ -1,8 +1,5 @@
 import { GetStaticProps, GetStaticPaths } from 'next'
-import {
-  collection,
-  type EntrySchema,
-} from '@/cms/collections/legal-docs-page'
+import { collection, type EntrySchema } from '@/cms/collections/legal-docs-page'
 import { getCollectionEntry } from '@/cms/getEntry'
 import { getSlugs } from '@/cms/getSlugs'
 import { Layout } from '@/components/Layout'
@@ -25,15 +22,17 @@ export const getStaticPaths: GetStaticPaths = async ({
   locales,
   defaultLocale,
 }) => {
-  const slugs = await getSlugs(collection)
-
-  const paths = (locales || [defaultLocale])
-    .map((locale) =>
-      slugs
-        .filter((slug) => slug !== INDEX_SLUG)
-        .map((slug) => ({ params: { slug }, locale }))
+  const localesToBuild = locales || [defaultLocale]
+  const paths = (
+    await Promise.all(
+      localesToBuild.map(async (locale) => {
+        const localeSlugs = await getSlugs(collection, locale)
+        return localeSlugs
+          .filter((slug) => slug !== INDEX_SLUG)
+          .map((slug) => ({ params: { slug }, locale }))
+      })
     )
-    .flat()
+  ).flat()
 
   return {
     paths,

--- a/src/pages/legal/docs/[slug].tsx
+++ b/src/pages/legal/docs/[slug].tsx
@@ -1,0 +1,67 @@
+import { GetStaticProps, GetStaticPaths } from 'next'
+import {
+  collection,
+  type EntrySchema,
+} from '@/cms/collections/legal-docs-page'
+import { getCollectionEntry } from '@/cms/getEntry'
+import { getSlugs } from '@/cms/getSlugs'
+import { Layout } from '@/components/Layout'
+import { PageContent } from '@/components/PageContent'
+import { Raw } from '@/components/Raw'
+
+const INDEX_SLUG = 'mentions-legales'
+
+export default function LegalDocsPage({ data }: { data: EntrySchema }) {
+  return (
+    <Layout title={data.title}>
+      <PageContent title={data.title}>
+        <Raw>{data.body}</Raw>
+      </PageContent>
+    </Layout>
+  )
+}
+
+export const getStaticPaths: GetStaticPaths = async ({
+  locales,
+  defaultLocale,
+}) => {
+  const slugs = await getSlugs(collection)
+
+  const paths = (locales || [defaultLocale])
+    .map((locale) =>
+      slugs
+        .filter((slug) => slug !== INDEX_SLUG)
+        .map((slug) => ({ params: { slug }, locale }))
+    )
+    .flat()
+
+  return {
+    paths,
+    fallback: false,
+  }
+}
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  if (!context.params?.slug || Array.isArray(context.params.slug)) {
+    throw Error('No page provided')
+  }
+
+  const content = await getCollectionEntry(
+    collection,
+    context.params.slug as string,
+    context.locale
+  )
+
+  if (
+    content.enabled === false ||
+    (!!context.locale &&
+      context.locale !== context.defaultLocale &&
+      content.enabled_i18n[context.locale] === false)
+  ) {
+    return { notFound: true }
+  }
+
+  return {
+    props: { data: content },
+  }
+}

--- a/src/pages/legal/docs/index.tsx
+++ b/src/pages/legal/docs/index.tsx
@@ -1,0 +1,44 @@
+import { GetStaticProps } from 'next'
+import {
+  collection,
+  type EntrySchema,
+} from '@/cms/collections/legal-docs-page'
+import { getCollectionEntry } from '@/cms/getEntry'
+import { Layout } from '@/components/Layout'
+import { PageContent } from '@/components/PageContent'
+import { Raw } from '@/components/Raw'
+
+export default function LegalDocsMentionsLegales({
+  data,
+}: {
+  data: EntrySchema
+}) {
+  return (
+    <Layout title={data.title}>
+      <PageContent title={data.title}>
+        <Raw>{data.body}</Raw>
+      </PageContent>
+    </Layout>
+  )
+}
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const content = await getCollectionEntry(
+    collection,
+    'mentions-legales',
+    context.locale
+  )
+
+  if (
+    content.enabled === false ||
+    (!!context.locale &&
+      context.locale !== context.defaultLocale &&
+      content.enabled_i18n[context.locale] === false)
+  ) {
+    return { notFound: true }
+  }
+
+  return {
+    props: { data: content },
+  }
+}

--- a/src/pages/legal/docs/index.tsx
+++ b/src/pages/legal/docs/index.tsx
@@ -1,8 +1,5 @@
 import { GetStaticProps } from 'next'
-import {
-  collection,
-  type EntrySchema,
-} from '@/cms/collections/legal-docs-page'
+import { collection, type EntrySchema } from '@/cms/collections/legal-docs-page'
 import { getCollectionEntry } from '@/cms/getEntry'
 import { Layout } from '@/components/Layout'
 import { PageContent } from '@/components/PageContent'

--- a/src/styles/cms.css
+++ b/src/styles/cms.css
@@ -64,6 +64,25 @@
   @apply underlined-link;
 }
 
+.content-page table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.content-page th,
+.content-page td {
+  border: 1px solid #e5e7eb;
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.content-page th {
+  font-weight: 600;
+}
+
 .with-content-links a:not([class]) {
   @apply underlined-link;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -74,3 +74,6 @@
   opacity: 1;
   height: auto !important;
 }
+.faq-answer a {
+  @apply underlined-link;
+}


### PR DESCRIPTION
## Purpose

Add Docs-specific legal pages on `lasuite.numerique.gouv.fr` and link them from `/produits/docs`, separate from LaSuite site-wide legal pages.

This PR following this demand : https://docs.numerique.gouv.fr/docs/df463c88-1fde-4283-bc61-ef2b79069604/

<img width="1252" height="697" alt="image" src="https://github.com/user-attachments/assets/da27a8ad-4a20-4fa7-b392-4b43c9811ae3" />

## Proposal

CMS collection + routes under `/legal/docs/*`, FAQ links, table/FAQ link styles. Reuses `Layout`, `PageContent`, `Raw`.

- [x] `/legal/docs` - legal notice (FR + EN)
- [x] `/legal/docs/donnees-personnelles-cookies` - privacy & cookies (FR + EN)
- [x] `/legal/docs/modalite-utilisation` - terms of use (FR + EN)
- [x] `/legal/docs/declaration-accessibilite`
- [x] FAQ on `/produits/docs` lists **4** underlined legal links