### PR TITLE
♿️(api) add accessibleName for France Transfert in services endpoint

### DIFF
--- a/src/pages/api/services.ts
+++ b/src/pages/api/services.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 interface Service {
   id: number
   name: string
+  accessibleName?: string
   url: string
   maturity: 'alpha' | 'beta' | 'stable'
   logo: string | null
@@ -67,6 +68,7 @@ export default async function handler(
     {
       id: 6,
       name: 'Fr. Transfert',
+      accessibleName: 'France Transfert',
       url: 'https://francetransfert.numerique.gouv.fr/',
       maturity: 'stable',
       logo: 'https://lasuite.numerique.gouv.fr/assets/products/france_transfert.svg',


### PR DESCRIPTION
## Purpose

Expose full accessible name for France Transfert in the `/api/services` endpoint ([suitenumerique/integration#49](https://github.com/suitenumerique/integration/issues/49)). The lagaufre widget can then announce the complete service name to screen readers while keeping the short display name.

## Proposal

* [x] Add optional `accessibleName` field to `Service` type
* [x] Set `accessibleName: "France Transfert"` for the France Transfert entry (display `name` stays `Fr. Transfert`)