### PR TITLE
♿(frontend) add accessible name to mobile header login link

### DIFF
--- a/src/components/LayoutProducts.tsx
+++ b/src/components/LayoutProducts.tsx
@@ -54,7 +54,11 @@ export const LayoutProducts: React.FC<{
           link={content.top_banner.link}
         />
       )}
-      <ProductsHeader productContent={content} slug={product.slug} />
+      <ProductsHeader
+        productContent={content}
+        slug={product.slug}
+        productTitle={product.title}
+      />
       <main>{children}</main>
       <Footer />
     </div>

--- a/src/components/content-blocks/ProductsHeader.tsx
+++ b/src/components/content-blocks/ProductsHeader.tsx
@@ -7,13 +7,15 @@ import { productLogos } from '@/assets/products/logosfull'
 import MenuIcon from '@mui/icons-material/Menu'
 import CloseIcon from '@mui/icons-material/Close'
 import { Button } from '@/components/ui-kit-v2/Button'
+import { useTranslations } from '@/locales/useTranslations'
 
 export type ProductContent = Record<string, any>
 
 const ProductsHeader: React.FC<{
   productContent: ProductContent
   slug: string
-}> = ({ productContent, slug }) => {
+  productTitle: string
+}> = ({ productContent, slug, productTitle }) => {
   const logoProduct = productLogos[slug]
 
   return (
@@ -37,7 +39,10 @@ const ProductsHeader: React.FC<{
             />
           </Link>
         </div>
-        <HeaderRight links={productContent?.header?.links} />
+        <HeaderRight
+          links={productContent?.header?.links}
+          productTitle={productTitle}
+        />
       </div>
     </header>
   )
@@ -66,7 +71,11 @@ const LoginIcon = () => (
   </svg>
 )
 
-const HeaderRight: React.FC<{ links?: HeaderLink[] }> = ({ links }) => {
+const HeaderRight: React.FC<{
+  links?: HeaderLink[]
+  productTitle: string
+}> = ({ links, productTitle }) => {
+  const t = useTranslations()
   const loginLink =
     Array.isArray(links) && links.length > 0 ? links[links.length - 1] : null
 
@@ -81,6 +90,10 @@ const HeaderRight: React.FC<{ links?: HeaderLink[] }> = ({ links }) => {
             icon={<LoginIcon />}
             className="!p-2 !min-w-0"
             target="_blank"
+            aria-label={t('common.login_to_product', {
+              title: loginLink.title,
+              product: productTitle,
+            })}
           ></Button>
         )}
       </div>

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -4,6 +4,7 @@ common:
   new_window: Neues Fenster
   know_more: Mehr erfahren
   back_to_home: Zurück zur Startseite
+  login_to_product: '{title} bei {product}'
   menu: Menü
   close: Schließen
   view_more: Mehr anzeigen

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -5,6 +5,7 @@ common:
   know_more: Know more
   back_to_home: Back to homepage
   login: Login
+  login_to_product: '{title} to {product}'
   menu: Menu
   close: Close
   view_more: See more

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -8,6 +8,7 @@ common:
   send: Envoyer
   footer: Pied de page
   login: Se connecter
+  login_to_product: '{title} à {product}'
   menu: Menu
   close: Fermer
   view_more: Voir plus

--- a/src/locales/nl.yml
+++ b/src/locales/nl.yml
@@ -4,6 +4,7 @@ common:
   new_window: Nieuw venster
   know_more: Meer weten
   back_to_home: Terug naar de startpagina
+  login_to_product: '{title} naar {product}'
   menu: Menu
   close: Sluiten
   view_more: Meer zien


### PR DESCRIPTION
## Purpose

The mobile header login link is icon-only and has no accessible name (RGAA 6.1). Desktop is already labelled.

Ticket : [197](https://github.com/numerique-gouv/lasuite-landingpage/issues/197)

<img width="1341" height="64" alt="Capture d&#39;écran 2026-08-27 094512" src="https://github.com/user-attachments/assets/7d9fc216-b15d-4453-9781-695b8381bc53" />

## Proposal

Add an `aria-label` on the mobile login link only, using a translated key and the product title. Result on Docs: `Se connecter à Docs - nouvelle fenêtre`.

- [x] `/produits/docs` < 1024px: icon link name is `Se connecter à Docs - nouvelle fenêtre`
- [x] Same check on Visio, Fichiers, Tchap
