### PR TITLE
♿(frontend) mark testimonials as quotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode/settings.json
 
 # debug
 npm-debug.log*

--- a/src/components/content-blocks/Testimonials.tsx
+++ b/src/components/content-blocks/Testimonials.tsx
@@ -109,9 +109,8 @@ export const Testimonials: React.FC<{ testimonials: TestimonialType[] }> = ({
           </svg>
           <div id={carouselId} className="grid" aria-live="polite">
             {testimonials.map((testimonial, idx) => (
-              <p
+              <blockquote
                 key={idx}
-                role="group"
                 aria-roledescription={t('common.slide')}
                 aria-label={getSlidePositionLabel(idx)}
                 aria-hidden={idx !== currentIndex}
@@ -124,7 +123,7 @@ export const Testimonials: React.FC<{ testimonials: TestimonialType[] }> = ({
                 }`}
               >
                 {testimonial.quote}
-              </p>
+              </blockquote>
             ))}
           </div>
           {total > 1 && (
@@ -172,9 +171,9 @@ export const Testimonials: React.FC<{ testimonials: TestimonialType[] }> = ({
           )}
           <div className="min-w-[200px] max-w-[300px]">
             {currentTestimonial.author && (
-              <p className="text-gray-850 text-base font-medium">
+              <cite className="block not-italic text-gray-850 text-base font-medium">
                 {currentTestimonial.author}
-              </p>
+              </cite>
             )}
 
             {currentTestimonial.role && (


### PR DESCRIPTION
## Purpose

Testimonials in the carousel are not marked as quotations, They currently use `<p role="group">`, and the author is a plain paragraph.

ticket : [196](https://github.com/numerique-gouv/lasuite-landingpage/issues/196)

<img width="596" height="176" alt="blockquote" src="https://github.com/user-attachments/assets/d0b00dbb-efbf-438f-b113-0ff19de2ea67" />
<img width="637" height="106" alt="cite" src="https://github.com/user-attachments/assets/264a5a83-4cc2-4874-9ec9-bb009148f2f7" />

## Proposal

Wrap each quote in `<blockquote>` and the author in `<cite>`. Drop `role="group"` on the quote so it does not override quotation semantics.

- [x] `/` or `/produits/docs`: quote is a `<blockquote>`, author is a `<cite>`
- [x] No `role="group"` on the testimonial quote