### PR TITLE
♿(frontend) structure grouped links as lists

### DIFF
--- a/src/components/content-blocks/FAQLinks.tsx
+++ b/src/components/content-blocks/FAQLinks.tsx
@@ -106,23 +106,24 @@ export const FAQLinks: React.FC<FAQLinksProps> = ({ links }) => {
 
   return (
     <div className="max-w-container w-[100%] mx-auto pt-12 md:pt-8 px-6 md:px-3 xl:px-0">
-      <div className="flex flex-wrap gap-4">
+      <ul role="list" className="flex flex-wrap gap-4 list-none p-0 m-0">
         {links.map((link, idx) => {
           const icon = link.icone ? iconMap[link.icone] : undefined
           return (
-            <Button
-              key={`faq-link-${idx}`}
-              href={link.url}
-              variant={(link.type as any) || 'primary_brand'}
-              icon={icon}
-              iconPosition="left"
-              target="_blank"
-            >
-              {link.title}
-            </Button>
+            <li key={`faq-link-${idx}`} className="w-full md:w-auto">
+              <Button
+                href={link.url}
+                variant={(link.type as any) || 'primary_brand'}
+                icon={icon}
+                iconPosition="left"
+                target="_blank"
+              >
+                {link.title}
+              </Button>
+            </li>
           )
         })}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/src/components/content-blocks/ProductsHeader.tsx
+++ b/src/components/content-blocks/ProductsHeader.tsx
@@ -2,7 +2,6 @@ import logoGouv from '@/assets/logo/gouv.svg'
 import Link from 'next/link'
 import Image from 'next/image'
 import { LaGaufre } from '@/components/LaGaufre'
-import { Fragment } from 'react'
 import { productLogos } from '@/assets/products/logosfull'
 import MenuIcon from '@mui/icons-material/Menu'
 import CloseIcon from '@mui/icons-material/Close'
@@ -85,12 +84,18 @@ const HeaderRight: React.FC<{ links?: HeaderLink[] }> = ({ links }) => {
         )}
       </div>
 
-      <div className="flex items-center gap-2 md:top-0 md:right-0 hidden lg:flex z-10 ml-auto">
-        {Array.isArray(links) &&
-          links.map((link, idx) => {
+      {Array.isArray(links) && links.length > 0 && (
+        <ul
+          role="list"
+          className="items-center gap-2 md:top-0 md:right-0 hidden lg:flex z-10 ml-auto list-none p-0 m-0"
+        >
+          {links.map((link, idx) => {
             const variant = (link.variant || link.type) as any
             return (
-              <Fragment key={`${link.title}-${idx}`}>
+              <li
+                key={`${link.title}-${idx}`}
+                className="flex items-center gap-2"
+              >
                 <Button
                   target="_blank"
                   href={link.url}
@@ -100,12 +105,16 @@ const HeaderRight: React.FC<{ links?: HeaderLink[] }> = ({ links }) => {
                   {link.title}
                 </Button>
                 {idx === 0 && links.length > 2 && (
-                  <span className="h-6 w-px rounded-[2px] bg-gray-100" />
+                  <span
+                    className="h-6 w-px rounded-[2px] bg-gray-100"
+                    aria-hidden="true"
+                  />
                 )}
-              </Fragment>
+              </li>
             )
           })}
-      </div>
+        </ul>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Purpose

Header quick-access links and FAQ link groups are visually grouped but not marked up as lists (RGAA 9.3).

ticket [195](https://github.com/numerique-gouv/lasuite-landingpage/issues/195)

<img width="1815" height="515" alt="btnlist" src="https://github.com/user-attachments/assets/6c0edfe9-8da6-4ee1-938d-a4df996dcdd2" />
<img width="1165" height="476" alt="headerlist" src="https://github.com/user-attachments/assets/da2bd42c-cc99-445e-ab0f-5073b9d13394" />


## Proposal

Wrap those two groups in `<ul>` / `<li>`, with `role="list"` so VoiceOver still exposes the list when styles reset `list-style`.

- [x] `/produits/docs` desktop header: 3 links in a list
- [x] FAQ buttons: list of 3 links, stacked full-width on mobile