### PR TITLE
♿(frontend) make Docs page title more explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode/settings.json
 
 # debug
 npm-debug.log*

--- a/src/components/LayoutProducts.tsx
+++ b/src/components/LayoutProducts.tsx
@@ -16,15 +16,17 @@ export const LayoutProducts: React.FC<{
   locale: string
 }> = ({ title, productContent, locale, children }) => {
   const isHomepage = title === TITLE_SITE
-  const pageTitle = isHomepage ? title : `${title} - ${TITLE_SITE}`
   const t = useTranslations()
   const product = productContent.global
   const content = productContent[locale] || productContent['fr']
+  const pageTitle = isHomepage
+    ? title
+    : `${product.title || title} - ${t('common.la_suite_numerique')}`
 
   return (
     <div className={`min-h-screen flex flex-col text-body'`}>
       <Head>
-        <title>{product.title || pageTitle}</title>
+        <title>{pageTitle}</title>
         <meta
           key="ogtitle"
           property="og:title"

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -1,5 +1,6 @@
 common:
   la_suite: La Suite numérique
+  la_suite_numerique: La Suite Numérique
   la_suite_territoriale: La Suite Territoriale
   new_window: Neues Fenster
   know_more: Mehr erfahren

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,5 +1,6 @@
 common:
   la_suite: LaSuite
+  la_suite_numerique: La Suite Numérique
   la_suite_territoriale: LaSuite Territoriale
   new_window: new window
   know_more: Know more

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -1,5 +1,6 @@
 common:
   la_suite: LaSuite
+  la_suite_numerique: La Suite Numérique
   la_suite_territoriale: LaSuite Territoriale
   new_window: nouvelle fenêtre
   know_more: En savoir plus

--- a/src/locales/nl.yml
+++ b/src/locales/nl.yml
@@ -1,5 +1,6 @@
 common:
   la_suite: La Suite numérique
+  la_suite_numerique: La Suite Numérique
   la_suite_territoriale: La Suite Territoriale
   new_window: Nieuw venster
   know_more: Meer weten


### PR DESCRIPTION
## Purpose

The Docs page title is only `Docs`, so users and AT cannot tell they are on the Docs page of La Suite Numérique (RGAA 8.6).

ticket [194](https://github.com/numerique-gouv/lasuite-landingpage/issues/194)

<img width="525" height="16" alt="docs_title" src="https://github.com/user-attachments/assets/2663c538-f5c6-4a23-805f-16603b33231b" />

<img width="475" height="16" alt="visio_title" src="https://github.com/user-attachments/assets/8cc21a2a-8e1c-42f2-ab8b-2bc7e04a5eca" />

## Proposal

Set the document title to `Docs - La Suite Numérique` in the product layout.

- [ ] `/produits/docs`: `<title>` is `Docs - La Suite Numérique`
- [ ] Homepage title unchanged