### PR TITLE
♿(frontend) hide closed FAQ accordion panels from AT

### DIFF
--- a/src/components/content-blocks/BlockFAQ.tsx
+++ b/src/components/content-blocks/BlockFAQ.tsx
@@ -98,6 +98,7 @@ const AccordionItem: FC<{
       </button>
       <div
         id={`faq-panel-${idx}`}
+        hidden={!open}
         className={`faq-answer ${open ? 'open pb-3' : ''} text-sm px-3.5 text-gray-600 max-w-[800px]`}
         dangerouslySetInnerHTML={{
           __html: answer,


### PR DESCRIPTION
## Purpose

Closed FAQ accordion answers stay in the accessibility tree, so screen readers can still read them when navigating the page (RGAA 7.1).

## Proposal

Add the `hidden` attribute on closed FAQ panels. The trigger stays reachable and still announces collapsed/expanded.

- [x] `/produits/docs` FAQ: closed panel has `hidden`, button is `aria-expanded="false"`
- [x] Opening a question removes `hidden` and the answer can be read
- [x] Screen reader browse mode does not read closed answers