### PR TITLE
♿(frontend) set testimonials nav buttons type to button

### DIFF
--- a/src/components/content-blocks/Testimonials.tsx
+++ b/src/components/content-blocks/Testimonials.tsx
@@ -131,6 +131,7 @@ export const Testimonials: React.FC<{ testimonials: TestimonialType[] }> = ({
             <div className="mt-8 inline-flex">
               <div className="flex items-center gap-2 px-2 h-10 rounded-lg border border-gray-100 bg-white shadow-[0_2px_8px_rgba(0,0,0,0.08)]">
                 <button
+                  type="button"
                   onClick={goToPrevious}
                   disabled={isFirst}
                   className={`transition-colors -mt-1 ${isFirst ? 'text-gray-300' : 'text-brand-550 cursor-pointer'}`}
@@ -146,6 +147,7 @@ export const Testimonials: React.FC<{ testimonials: TestimonialType[] }> = ({
                   </span>
                 </span>
                 <button
+                  type="button"
                   onClick={goToNext}
                   disabled={isLast}
                   className={`transition-colors -mt-1 ${isLast ? 'text-gray-300' : 'text-brand-550 cursor-pointer'}`}


### PR DESCRIPTION
## Purpose

Testimonials carousel prev/next buttons have no explicit `type`. They are UI actions, not submit buttons (RGAA 7.1).

<img width="543" height="68" alt="Capture d&#39;écran 2026-08-28 134312" src="https://github.com/user-attachments/assets/c74609f9-6a15-4aac-8d61-87d02e9aa80c" />

## Proposal

Add `type="button"` on both navigation buttons.

- [x] `/produits/docs` testimonials: prev/next buttons have `type="button"`
- [x] Prev/next still change the current slide