### PR TITLE
♿(frontend) hide decorative Docs CTA image from AT

### DIFF
--- a/src/content/products/docs.json
+++ b/src/content/products/docs.json
@@ -297,7 +297,7 @@
       },
       "image": {
         "src": "docs/cta/image_cta.png",
-        "alt": "docs illustration"
+        "alt": ""
       }
     },
     "decisions": {


### PR DESCRIPTION
## Purpose

The Docs footer CTA illustration has `alt="docs illustration"`. It is decorative and should be ignored by assistive technologies (RGAA 1.2).

<img width="576" height="117" alt="docsalt" src="https://github.com/user-attachments/assets/1d24b2a3-959b-477f-9e80-a70da1a54319" />


## Proposal

Set the image alternative text to an empty string.

- [x] `/produits/docs` desktop: CTA image has `alt=""`
- [x] Screen reader does not announce the illustration
