### PR TITLE
♿(frontend) complete Docs roadmap image alternative text

### DIFF
--- a/src/content/products/docs.json
+++ b/src/content/products/docs.json
@@ -272,11 +272,11 @@
         },
         {
           "src": "docs/roadmap/collab.png",
-          "alt": "Collaboration avec les commentaires"
+          "alt": "Collaboration avec les commentaires - Fonctionnalité implémentée"
         },
         {
           "src": "docs/roadmap/import.png",
-          "alt": "Importation des nouveaux formats : Word, OTF, markdown, et d’autres à venir…"
+          "alt": "Importation des nouveaux formats : Docx et Markdown - Fonctionnalité implémentée"
         },
         {
           "src": "docs/roadmap/more.png",


### PR DESCRIPTION
## Purpose

Some Docs roadmap images show both a feature name and an “Implémenté” status, but the alt only names the feature (RGAA 1.1 / 1.3).
<img width="615" height="139" alt="implem" src="https://github.com/user-attachments/assets/af6d92c8-05ab-496c-98e0-77cea09d33a1" />


<img width="607" height="132" alt="imple" src="https://github.com/user-attachments/assets/f6f0a570-9b2b-4032-a51d-92d0a90fc5f7" />

## Proposal

Update those alts so they include the implementation status, matching the visual content.

- [x] `/produits/docs` roadmap: collab image alt is `Collaboration avec les commentaires - Fonctionnalité implémentée`
- [x] Import image alt is `Importation des nouveaux formats : Docx et Markdown - Fonctionnalité implémentée`