### PR TITLE
♿(frontend) fix full product logo alternative text

### DIFF
--- a/src/components/content-blocks/ProductsFooter.tsx
+++ b/src/components/content-blocks/ProductsFooter.tsx
@@ -10,6 +10,7 @@ export const ProductsFooter: React.FC<{
   slug: string
 }> = ({ productContent, slug }) => {
   const logoProduct = productLogos[slug]
+  const productName = slug.charAt(0).toUpperCase() + slug.slice(1)
 
   return productContent.footer ? (
     <div className="py-12 md:py-[120px] mx-auto bg-gray-025 text-center px-6 md:px-0">
@@ -19,7 +20,7 @@ export const ProductsFooter: React.FC<{
           src={logoProduct.src}
           width={432}
           height={96}
-          alt={`logo ${slug}`}
+          alt={`LaSuite ${productName}`}
         />
       ) : null}
 

--- a/src/components/content-blocks/ProductsHeader.tsx
+++ b/src/components/content-blocks/ProductsHeader.tsx
@@ -15,6 +15,7 @@ const ProductsHeader: React.FC<{
   slug: string
 }> = ({ productContent, slug }) => {
   const logoProduct = productLogos[slug]
+  const productName = slug.charAt(0).toUpperCase() + slug.slice(1)
 
   return (
     <header className="max-w-container w-[100%] mx-auto fade-in bg-white md:px-3 xl:px-0 px-4">
@@ -33,7 +34,7 @@ const ProductsHeader: React.FC<{
               height={40}
               className="md:block"
               src={logoProduct.src}
-              alt={`LaSuite ${slug}`}
+              alt={`LaSuite ${productName}`}
             />
           </Link>
         </div>


### PR DESCRIPTION
## Purpose

The full LaSuite Docs logo uses `alt="logo docs"`. Screen readers already announce an image, so “logo” is noise (RGAA 1.1).

<img width="612" height="118" alt="docslogo" src="https://github.com/user-attachments/assets/c812f1e3-349c-4ed4-9403-8d29f647bd4a" />

## Proposal

Set the alternative text to the visible brand name: `LaSuite Docs`. Applied wherever that full product logo is shown (footer and header).

- [ ] `/produits/docs` footer logo: `alt="LaSuite Docs"`
- [ ] Header logo: `alt="LaSuite Docs"`
- [ ] Screen reader announces the brand, not “logo”