### PR TITLE
♿(frontend) add alternative text to organization logos

### DIFF
--- a/src/components/content-blocks/SocialProof.tsx
+++ b/src/components/content-blocks/SocialProof.tsx
@@ -30,7 +30,7 @@ export const SocialProof: React.FC<{ socialProof: SocialProofProps }> = ({
           <div key={`social-proof-${idx}`} className="snap-start shrink-0">
             <Image
               src={`/assets/${item.src}`}
-              alt=""
+              alt={item.title}
               height={item.height || 32}
               width={item.width || 80}
             />


### PR DESCRIPTION
## Purpose

Organization logos in the “Quinze ministères…” block have an empty `alt`, so screen reader users cannot tell who already uses Docs (RGAA 1.1).

<img width="462" height="217" alt="logoministry" src="https://github.com/user-attachments/assets/6f0a07ae-8c6a-4c4a-a512-579ec71a770f" />

## Proposal

Use each item’s existing `title` as the image alternative text.

- [x] `/produits/docs` social-proof logos have meaningful French `alt` (not empty)
- [x] Each organization is announced once
