### PR TITLE
♿(frontend) expand Fr. Transfert accessible name

### DIFF
--- a/src/pages/api/services.ts
+++ b/src/pages/api/services.ts
@@ -68,7 +68,7 @@ export default async function handler(
     {
       id: 6,
       name: 'Fr. Transfert',
-      accessibleName: 'France Transfert',
+      accessibleName: 'Fr. Transfert (France Transfert)',
       url: 'https://francetransfert.numerique.gouv.fr/',
       maturity: 'stable',
       logo: 'https://lasuite.numerique.gouv.fr/assets/products/france_transfert.svg',


### PR DESCRIPTION
## Purpose

The gaufre currently exposes “France Transfert” as the accessible name, which does not match the visible abbreviated label “Fr. Transfert”. Screen reader users therefore hear a different name from the one shown on screen.

following the discussion in [this](https://github.com/suitenumerique/integration/pull/59) PR 

<img width="482" height="98" alt="fr_transfert" src="https://github.com/user-attachments/assets/0b646708-d228-453b-bc7c-f7cec56efb71" />

## Proposal

Update the Fr. Transfert `accessibleName` so assistive technologies announce both the visible abbreviation and the full product name.

- [x] `accessibleName` becomes `Fr. Transfert (France Transfert)`
